### PR TITLE
Supported Coil as another image loader in addition to Glide and Picasso.

### DIFF
--- a/client/android/coil/build.gradle
+++ b/client/android/coil/build.gradle
@@ -1,0 +1,15 @@
+apply from: "../div-library.gradle"
+apply from: "../div-tests.gradle"
+apply from: "../publish-android.gradle"
+
+android {
+    namespace "com.yandex.divkit.coil"
+}
+
+dependencies {
+    implementation project(path: ':div')
+    implementation project(path: ':div-core')
+
+    api "io.coil-kt:coil:2.4.0"
+    api "io.coil-kt:coil-svg:2.4.0"
+}

--- a/client/android/coil/build.gradle
+++ b/client/android/coil/build.gradle
@@ -9,6 +9,7 @@ android {
 dependencies {
     implementation project(path: ':div')
     implementation project(path: ':div-core')
+    implementation("io.coil-kt:coil-gif:2.5.0")
 
     api "io.coil-kt:coil:2.4.0"
     api "io.coil-kt:coil-svg:2.4.0"

--- a/client/android/coil/jacoco.excludes
+++ b/client/android/coil/jacoco.excludes
@@ -1,0 +1,7 @@
+#####################
+# Generated classes #
+#####################
+**/R.class
+**/R$*.class
+**/BuildConfig.*
+**/Manifest*.*

--- a/client/android/coil/proguard-rules.pro
+++ b/client/android/coil/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/client/android/coil/src/main/java/com/yandex/div/coil/CoilDivImageLoader.kt
+++ b/client/android/coil/src/main/java/com/yandex/div/coil/CoilDivImageLoader.kt
@@ -1,0 +1,85 @@
+package com.yandex.div.coil
+
+import android.content.Context
+import android.graphics.drawable.BitmapDrawable
+import android.net.Uri
+import android.widget.ImageView
+import coil.EventListener
+import coil.ImageLoader
+import coil.decode.DataSource
+import coil.decode.SvgDecoder
+import coil.load
+import coil.request.ErrorResult
+import coil.request.ImageRequest
+import coil.request.SuccessResult
+import com.yandex.div.core.images.BitmapSource
+import com.yandex.div.core.images.CachedBitmap
+import com.yandex.div.core.images.DivImageDownloadCallback
+import com.yandex.div.core.images.DivImageLoader
+import com.yandex.div.core.images.LoadReference
+
+class CoilDivImageLoader(
+    private val context: Context
+) : DivImageLoader {
+
+    private val imageLoader = ImageLoader.Builder(context)
+        .components {
+            add(SvgDecoder.Factory())
+        }
+        .build()
+
+    override fun loadImage(imageUrl: String, imageView: ImageView): LoadReference {
+        val imageUri = Uri.parse(imageUrl)
+
+        val result = imageView.load(imageUri, imageLoader)
+
+        return LoadReference {
+            result.dispose()
+        }
+    }
+
+    override fun loadImage(imageUrl: String, callback: DivImageDownloadCallback): LoadReference {
+        val imageUri = Uri.parse(imageUrl)
+
+        val request = ImageRequest.Builder(context)
+            .data(imageUri)
+            .allowHardware(false)
+            .listener(BitmapRequestListener(callback, imageUri))
+            .build()
+
+        val result = imageLoader.enqueue(request)
+
+        return LoadReference {
+            result.dispose()
+        }
+    }
+
+    override fun loadImageBytes(
+        imageUrl: String,
+        callback: DivImageDownloadCallback
+    ): LoadReference {
+        return loadImage(imageUrl, callback)
+    }
+
+    private class BitmapRequestListener(
+        private val callback: DivImageDownloadCallback,
+        private val imageUri: Uri,
+    ): EventListener {
+        override fun onSuccess(request: ImageRequest, result: SuccessResult) {
+            callback.onSuccess(CachedBitmap((result.drawable as BitmapDrawable).bitmap, imageUri, result.dataSource.toBitmapSource()))
+        }
+
+        override fun onError(request: ImageRequest, result: ErrorResult) {
+            callback.onError()
+        }
+    }
+}
+
+private fun DataSource.toBitmapSource(): BitmapSource {
+    return when (this) {
+        DataSource.MEMORY -> BitmapSource.MEMORY
+        DataSource.DISK -> BitmapSource.DISK
+        DataSource.NETWORK -> BitmapSource.NETWORK
+        DataSource.MEMORY_CACHE -> BitmapSource.MEMORY
+    }
+}

--- a/client/android/div-core/src/main/java/com/yandex/div/core/images/DivImageDownloadCallback.java
+++ b/client/android/div-core/src/main/java/com/yandex/div/core/images/DivImageDownloadCallback.java
@@ -1,5 +1,7 @@
 package com.yandex.div.core.images;
 
+import android.graphics.drawable.Drawable;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
@@ -13,6 +15,16 @@ public class DivImageDownloadCallback {
      */
     @UiThread
     public void onSuccess(@NonNull CachedBitmap cachedBitmap) {
+        // no implementation
+    }
+
+    /**
+     * Called when image is successfully loaded in a form of drawable
+     * Use when you want to draw Drawable object directly
+     * Ex.: Coil GIFs
+     */
+    @UiThread
+    public void onSuccess(@NonNull Drawable drawable) {
         // no implementation
     }
 

--- a/client/android/div/src/main/java/com/yandex/div/core/view2/divs/DivGifImageBinder.kt
+++ b/client/android/div/src/main/java/com/yandex/div/core/view2/divs/DivGifImageBinder.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.graphics.ImageDecoder
 import android.graphics.drawable.AnimatedImageDrawable
 import android.graphics.drawable.Drawable
+import android.graphics.drawable.PictureDrawable
+import android.graphics.drawable.ScaleDrawable
 import android.os.AsyncTask
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -128,6 +130,12 @@ internal class DivGifImageBinder @Inject constructor(
                         setImage(cachedBitmap.bitmap)
                         imageLoaded()
                     }
+                }
+
+                override fun onSuccess(drawable: Drawable) {
+                    super.onSuccess(drawable)
+                    setImage(drawable)
+                    imageLoaded()
                 }
 
                 override fun onError() {

--- a/client/android/divkit-demo-app/build.gradle
+++ b/client/android/divkit-demo-app/build.gradle
@@ -100,6 +100,7 @@ dependencies {
     implementation project(path: ':div-video')
     implementation project(path: ':picasso')
     implementation project(path: ':glide')
+    implementation project(path: ':coil')
 
     implementation "androidx.browser:browser:$versions.androidx.browser"
     implementation "androidx.constraintlayout:constraintlayout:$versions.androidx.constraint"

--- a/client/android/divkit-demo-app/src/main/assets/application/settings.json
+++ b/client/android/divkit-demo-app/src/main/assets/application/settings.json
@@ -137,6 +137,66 @@
                 }
             ]
         },
+        "slider_preset": {
+            "type": "slider",
+            "width": {
+                "type": "match_parent"
+            },
+            "paddings": {
+                "left": 8,
+                "right": 8,
+                "top": 8,
+                "bottom": 8
+            },
+            "max_value": 10,
+            "min_value": 1,
+            "thumb_value_variable": "first_thumb_value",
+            "thumb_style": {
+                "type": "shape_drawable",
+                "color": "#FFCC00",
+                "stroke": {
+                    "color": "#ffffff",
+                    "width": 3
+                },
+                "shape": {
+                    "type": "rounded_rectangle",
+                    "item_height": {
+                        "type": "fixed",
+                        "value": 32
+                    },
+                    "item_width": {
+                        "type": "fixed",
+                        "value": 32
+                    },
+                    "corner_radius": {
+                        "type": "fixed",
+                        "value": 100
+                    }
+                }
+            },
+            "track_active_style": {
+                "type": "shape_drawable",
+                "color": "#d3d3d3",
+                "shape": {
+                    "type": "rounded_rectangle",
+                    "item_height": {
+                        "type": "fixed",
+                        "value": 6
+                    }
+                }
+            },
+            "track_inactive_style": {
+                "type": "shape_drawable",
+                "color": "#d3d3d3",
+                "shape": {
+                    "type": "rounded_rectangle",
+                    "item_height": {
+                        "type": "fixed",
+                        "value": 6
+                    }
+                }
+            }
+        },
         "settings_category": {
             "type": "text",
             "font_size": 20,
@@ -225,6 +285,21 @@
     },
     "card": {
         "log_id": "settings",
+        "variable_triggers": [
+            {
+                "condition": "@{image_loader != prev_image_loader}",
+                "actions": [
+                    {
+                        "log_id": "change_image_loader",
+                        "url": "div-action://set_preferences?name=image_loader&value=@{image_loader}"
+                    },
+                    {
+                        "log_id": "change_prev_image_loader",
+                        "url": "div-action://set_variable?name=prev_image_loader&value=@{image_loader}"
+                    }
+                ]
+            }
+        ],
         "variables": [
             {
                 "name": "night_mode",
@@ -235,6 +310,16 @@
                 "name": "app_version",
                 "type": "string",
                 "value": "DivKit"
+            },
+            {
+                "name": "image_loader",
+                "type": "integer",
+                "value": 0
+            },
+            {
+                "name": "prev_image_loader",
+                "type": "integer",
+                "value": 0
             }
         ],
         "states": [
@@ -349,21 +434,90 @@
                         },
                         {
                             "type": "settings_item",
+                            "orientation": "vertical",
                             "items": [
                                 {
                                     "type": "settings_item_title",
-                                    "text": "Div image loader.\nInactive = GlideDivImageLoader.\nActive = PicassoImageLoader."
+                                    "text": "Div image loader"
                                 },
                                 {
-                                    "type": "setting_switch_state",
-                                    "div_id": "image_loader",
-                                    "content_alignment_vertical": "center",
-                                    "active_click_log_id": "set_glide_image_loader",
-                                    "active_click_change_state_url": "div-action://set_state?state_id=0/image_loader/inactive",
-                                    "active_click_change_settings_url": "div-action://set_preferences?name=image_loader&value=0",
-                                    "inactive_click_log_id": "set_picasso_image_loader",
-                                    "inactive_click_change_settings_url": "div-action://set_preferences?name=image_loader&value=1",
-                                    "inactive_click_change_state_url": "div-action://set_state?state_id=0/image_loader/active"
+                                    "type": "slider_preset",
+                                    "div_id": "slider_default",
+                                    "min_value": 0,
+                                    "max_value": 2,
+                                    "thumb_value_variable": "image_loader",
+                                    "accessibility": {
+                                        "description": "Min - 0, max - 2"
+                                    },
+                                    "tick_mark_active_style": {
+                                        "type": "shape_drawable",
+                                        "color": "#20000000",
+                                        "stroke": {
+                                            "color": "#ffffff",
+                                            "width": 2
+                                        },
+                                        "shape": {
+                                            "type": "rounded_rectangle",
+                                            "item_height": {
+                                                "type": "fixed",
+                                                "value": 8
+                                            },
+                                            "item_width": {
+                                                "type": "fixed",
+                                                "value": 8
+                                            },
+                                            "corner_radius": {
+                                                "type": "fixed",
+                                                "value": 5
+                                            }
+                                        }
+                                    },
+                                    "tick_mark_inactive_style": {
+                                        "type": "shape_drawable",
+                                        "color": "#20000000",
+                                        "stroke": {
+                                            "color": "#ffffff",
+                                            "width": 2
+                                        },
+                                        "shape": {
+                                            "type": "rounded_rectangle",
+                                            "item_height": {
+                                                "type": "fixed",
+                                                "value": 8
+                                            },
+                                            "item_width": {
+                                                "type": "fixed",
+                                                "value": 8
+                                            },
+                                            "corner_radius": {
+                                                "type": "fixed",
+                                                "value": 5
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "container",
+                                    "orientation": "horizontal",
+                                    "width": {
+                                        "type": "fixed",
+                                        "value": 410
+                                    },
+                                    "content_alignment_horizontal": "space-between",
+                                    "items": [
+                                        {
+                                            "type": "settings_item_subtitle",
+                                            "text": "Picasso"
+                                        },
+                                        {
+                                            "type": "settings_item_subtitle",
+                                            "text": "Glide"
+                                        },
+                                        {
+                                            "type": "settings_item_subtitle",
+                                            "text": "Coil"
+                                        }
+                                    ]
                                 }
                             ]
                         },

--- a/client/android/divkit-demo-app/src/main/java/com/yandex/divkit/demo/Container.kt
+++ b/client/android/divkit-demo-app/src/main/java/com/yandex/divkit/demo/Container.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.os.Build
 import com.facebook.stetho.okhttp3.StethoInterceptor
 import com.neovisionaries.ws.client.WebSocketFactory
+import com.yandex.div.coil.CoilDivImageLoader
 import com.yandex.div.core.DivKit
 import com.yandex.div.glide.GlideDivImageLoader
 import com.yandex.div.histogram.HistogramBridge
@@ -82,10 +83,10 @@ internal object Container {
     }
 
     val imageLoader by lazy {
-        if (preferences.imageLoader) {
-            PicassoDivImageLoader(context, httpClientBuilder)
-        } else {
-            GlideDivImageLoader(context)
+        when (preferences.imageLoader) {
+            Preferences.ImageLoaderOption.PICASSO -> PicassoDivImageLoader(context, httpClientBuilder)
+            Preferences.ImageLoaderOption.GLIDE -> GlideDivImageLoader(context)
+            Preferences.ImageLoaderOption.COIL -> CoilDivImageLoader(context)
         }
     }
 

--- a/client/android/divkit-demo-app/src/main/java/com/yandex/divkit/demo/settings/DivkitDemoPreferences.kt
+++ b/client/android/divkit-demo-app/src/main/java/com/yandex/divkit/demo/settings/DivkitDemoPreferences.kt
@@ -32,6 +32,7 @@ open class DivkitDemoPreferences(protected val context: Context) {
         val valueToSet: Any? = when (property.returnType) {
             Boolean::class.createType() -> value.toBoolean()
             Float::class.createType() -> value.toFloatOrNull()
+            Preferences.ImageLoaderOption::class.createType() -> (value as Preferences.ImageLoaderOption)
             Int::class.createType() -> value.toIntOrNull()
             Long::class.createType() -> value.toLongOrNull()
             String::class.createType(), String::class.createType(nullable = true) -> value

--- a/client/android/divkit-demo-app/src/main/java/com/yandex/divkit/demo/settings/Preferences.kt
+++ b/client/android/divkit-demo-app/src/main/java/com/yandex/divkit/demo/settings/Preferences.kt
@@ -9,5 +9,15 @@ class Preferences(context: Context) : DivkitDemoPreferences(context) {
 
     var nightMode by IntPreference(AppCompatDelegate.MODE_NIGHT_NO)
 
-    var imageLoader by BooleanPreference(true)
+    enum class ImageLoaderOption(val value: Int) {
+        PICASSO(0),
+        GLIDE(1),
+        COIL(2);
+
+        companion object {
+            fun fromInt(value: Int) = ImageLoaderOption.values().first { it.value == value }
+        }
+    }
+
+    var imageLoader by EnumPreference(ImageLoaderOption.PICASSO) { ImageLoaderOption.values() }
 }

--- a/client/android/divkit-demo-app/src/main/java/com/yandex/divkit/demo/settings/SettingsActionHandler.kt
+++ b/client/android/divkit-demo-app/src/main/java/com/yandex/divkit/demo/settings/SettingsActionHandler.kt
@@ -31,32 +31,29 @@ internal object SettingsActionHandler {
 
         val value = uri.getQueryParameter(PARAM_VALUE)
 
-        if (value?.toIntOrNull() != null) {
-            val valueBool = value.toIntOrNull()!! > 0
-            when (uri.getQueryParameter(PARAM_NAME)) {
-                COMPLEX_REBIND -> setPreferencesBooleanFlag(Experiment.COMPLEX_REBIND_ENABLED, valueBool)
-                DIV2_VIEW_POOL -> setPreferencesBooleanFlag(Experiment.VIEW_POOL_ENABLED, valueBool)
-                DIV2_VIEW_POOL_PROFILING -> setPreferencesBooleanFlag(Experiment.VIEW_POOL_PROFILING_ENABLED, valueBool)
-                DIV2_MULTIPLE_STATE_CHANGE -> setPreferencesBooleanFlag(Experiment.MULTIPLE_STATE_CHANGE_ENABLED, valueBool)
-                DIV2_DEMO_SHOW_RENDERING_TIME -> setPreferencesBooleanFlag(Experiment.SHOW_RENDERING_TIME, valueBool)
-                IMAGE_LOADER -> Container.preferences.imageLoader = valueBool
-                else -> return false
+        when (uri.getQueryParameter(PARAM_NAME)) {
+            IMAGE_LOADER -> {
+                val valueInt = value?.toIntOrNull() ?: 0
+                Container.preferences.imageLoader = Preferences.ImageLoaderOption.fromInt(valueInt)
             }
-        } else {
-            when(uri.getQueryParameter(PARAM_NAME)) {
-                NIGHT_MODE ->  {
-                    when(value) {
-                        NIGHT_MODE_AUTO -> Container.preferences.nightMode = AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-                        NIGHT_MODE_NIGHT -> Container.preferences.nightMode = AppCompatDelegate.MODE_NIGHT_YES
-                        NIGHT_MODE_DAY -> Container.preferences.nightMode = AppCompatDelegate.MODE_NIGHT_NO
-                        else -> return false
-                    }
-                    AppCompatDelegate.setDefaultNightMode(Container.preferences.nightMode)
-                    return true
+            NIGHT_MODE -> {
+                when (value) {
+                    NIGHT_MODE_AUTO -> Container.preferences.nightMode = AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+                    NIGHT_MODE_NIGHT -> Container.preferences.nightMode = AppCompatDelegate.MODE_NIGHT_YES
+                    NIGHT_MODE_DAY -> Container.preferences.nightMode = AppCompatDelegate.MODE_NIGHT_NO
+                    else -> return false
                 }
-                else -> return false
+                AppCompatDelegate.setDefaultNightMode(Container.preferences.nightMode)
+                return true
             }
+            COMPLEX_REBIND -> setPreferencesBooleanFlag(Experiment.COMPLEX_REBIND_ENABLED, value.toBoolean())
+            DIV2_VIEW_POOL -> setPreferencesBooleanFlag(Experiment.VIEW_POOL_ENABLED, value.toBoolean())
+            DIV2_VIEW_POOL_PROFILING -> setPreferencesBooleanFlag(Experiment.VIEW_POOL_PROFILING_ENABLED, value.toBoolean())
+            DIV2_MULTIPLE_STATE_CHANGE -> setPreferencesBooleanFlag(Experiment.MULTIPLE_STATE_CHANGE_ENABLED, value.toBoolean())
+            DIV2_DEMO_SHOW_RENDERING_TIME -> setPreferencesBooleanFlag(Experiment.SHOW_RENDERING_TIME, value.toBoolean())
+            else -> return false
         }
+
         return true
     }
 

--- a/client/android/divkit-demo-app/src/main/java/com/yandex/divkit/demo/settings/SettingsActivity.kt
+++ b/client/android/divkit-demo-app/src/main/java/com/yandex/divkit/demo/settings/SettingsActivity.kt
@@ -92,8 +92,10 @@ class SettingsActivity : AppCompatActivity() {
             AppCompatDelegate.MODE_NIGHT_NO -> NIGHT_MODE_DAY
             else -> NIGHT_MODE_AUTO
         }
+
+        val imageLoader = Container.preferences.imageLoader.value
+        div2View.setVariable(IMAGE_LOADER, imageLoader.toString())
         div2View.setVariable(NIGHT_MODE, nightMode)
-        setPreferenceState(IMAGE_LOADER, Container.preferences.imageLoader)
 
         val appName = resources.getText(R.string.app_name)
         val appVersion = "$appName ${BuildConfig.VERSION_NAME}.${BuildConfig.BUILD_NUMBER} ${BuildConfig.BUILD_TYPE}"

--- a/client/android/settings.gradle
+++ b/client/android/settings.gradle
@@ -5,6 +5,7 @@ includeBuild('screenshot-test-plugin')
 include ':api-generator-test'
 include ':assertion'
 include ':beacon'
+include ':coil'
 include ':div'
 include ':div-core'
 include ':div-data'


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: [link](https://yandex.ru/legal/cla/?lang=en)

### Notes
* Added Coil library for loading images and supported:
  * SvgDecoder to load vector images;
  * GifDecoder to load animatable images.
* Changed image loader picker in the settings from boolean switch to slider to be able to choose between 3 options:
<img width="307" alt="Screenshot 2023-11-25 at 15 04 36" src="https://github.com/divkit/divkit/assets/50011154/6a0f5b7a-f6db-4d2b-9311-c7a46aed5440">