### PR TITLE
Added support for SVG images.

### DIFF
--- a/client/android/coil/src/main/java/com/yandex/div/coil/CoilDivImageLoader.kt
+++ b/client/android/coil/src/main/java/com/yandex/div/coil/CoilDivImageLoader.kt
@@ -38,6 +38,10 @@ class CoilDivImageLoader(
         }
         .build()
 
+    override fun doesSupportSvg(): Boolean {
+        return true
+    }
+
     override fun loadImage(imageUrl: String, imageView: ImageView): LoadReference {
         val imageUri = Uri.parse(imageUrl)
 

--- a/client/android/div-core/src/main/java/com/yandex/div/core/images/DivImageDownloadCallback.java
+++ b/client/android/div-core/src/main/java/com/yandex/div/core/images/DivImageDownloadCallback.java
@@ -1,6 +1,7 @@
 package com.yandex.div.core.images;
 
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.PictureDrawable;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -25,6 +26,16 @@ public class DivImageDownloadCallback {
      */
     @UiThread
     public void onSuccess(@NonNull Drawable drawable) {
+        // no implementation
+    }
+
+    /**
+     * Called when image is successfully loaded in a form of picture drawable
+     * Use when you want to draw PictureDrawable object directly
+     * Ex.: Vector images in SVG Image Loader
+     */
+    @UiThread
+    public void onSuccess(@NonNull PictureDrawable pictureDrawable) {
         // no implementation
     }
 

--- a/client/android/div-core/src/main/java/com/yandex/div/core/images/DivImageLoader.java
+++ b/client/android/div-core/src/main/java/com/yandex/div/core/images/DivImageLoader.java
@@ -5,6 +5,8 @@ import android.widget.ImageView;
 import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Image loader contract.
  */
@@ -22,6 +24,33 @@ public interface DivImageLoader {
     @MainThread
     @NonNull
     LoadReference loadImage(@NonNull String imageUrl, @NonNull DivImageDownloadCallback callback);
+
+    /**
+     * Starts image loading with a given <code>imageUrl</code>.
+     * If not overridden, works as loadImage(imageUrl, callback)
+     * <p>
+     * Contract : <code>callback</code> MUST BE stored in {@link java.lang.ref.WeakReference} in order to prevent leakage.
+     *
+     * @param imageUrl image url.
+     * @param shouldBeRasterized property indicating if the vector image should be rasterized
+     * @param callback callback to invoke after image is loaded.
+     * @return reference to cancel loading
+     */
+    @MainThread
+    @NonNull
+    default LoadReference loadImage(@NonNull String imageUrl, @NotNull boolean shouldBeRasterized, @NonNull DivImageDownloadCallback callback) {
+        return loadImage(imageUrl, callback);
+    }
+
+    /**
+     * Property indicating if the image loader can handle svg.
+     * False if not overridden.
+     *
+     * @return true if image loader supports svg.
+     */
+    default Boolean doesSupportSvg() {
+        return false;
+    }
 
     /**
      * Starts image loading by given <code>imageUrl</code>. Download raw bytes in result.

--- a/client/android/div/build.gradle
+++ b/client/android/div/build.gradle
@@ -47,6 +47,8 @@ dependencies {
     implementation("androidx.viewpager2:viewpager2:$versions.androidx.viewpager2") {
         exclude group: "androidx.fragment", module: "fragment"
     }
+    implementation 'com.caverock:androidsvg-aar:1.4'
+    implementation "com.squareup.okhttp3:okhttp:$versions.okhttp"
 
     implementation "androidx.datastore:datastore:$versions.dataStore"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$versions.kotlinSerialization"

--- a/client/android/div/src/main/java/com/yandex/div/core/DecodeBase64ImageTask.kt
+++ b/client/android/div/src/main/java/com/yandex/div/core/DecodeBase64ImageTask.kt
@@ -2,49 +2,106 @@ package com.yandex.div.core
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.drawable.PictureDrawable
 import android.util.Base64
 import androidx.annotation.WorkerThread
+import androidx.core.graphics.drawable.toBitmap
+import com.yandex.div.core.svg.SvgDecoder
+import com.yandex.div.core.util.ImageRepresentation
+
 import com.yandex.div.internal.KLog
 import com.yandex.div.internal.util.UiThreadHandler
 
 internal class DecodeBase64ImageTask(
     private var base64string: String,
     private val synchronous: Boolean,
-    private val onDecoded: (Bitmap?) -> Unit
+    private val shouldBeRasterized: Boolean,
+    private val onDecoded: (ImageRepresentation<Any>?) -> Unit
 ) : Runnable {
+
+    private val svgDecoder = SvgDecoder()
 
     @WorkerThread
     override fun run() {
-        base64string = extractFromDataUrl(base64string)
+        val imageFormat = extractFormatFromDataUrlOrNull(base64string)
+        base64string = extractDataFromDataUrl(base64string)
         val bytes = try {
             Base64.decode(base64string, Base64.DEFAULT)
         } catch (e: IllegalArgumentException) {
             KLog.e("Div") { "Bad base-64 image preview" }
             return
         }
+
+        // Decode to an appropriate format if it's specified in the preview
+        // Otherwise, make a guess and try decoding to both
+        val decoded: ImageRepresentation<Any> = imageFormat?.let {
+            if (imageFormat == "svg") {
+                getAppropriateSvgRepresentation(decodeToPictureDrawable(bytes))
+            } else {
+                ImageRepresentation.Bitmap(decodeToBitmap(bytes))
+            }
+        } ?: tryDecodeToBoth(bytes)
+
+        if (synchronous) {
+            onDecoded(decoded)
+        } else {
+            UiThreadHandler.postOnMainThread {
+                onDecoded(decoded)
+            }
+        }
+    }
+
+    private fun tryDecodeToBoth(bytes: ByteArray): ImageRepresentation<Any> {
+        decodeToBitmap(bytes)?.let {
+            return ImageRepresentation.Bitmap(it)
+        } ?: return getAppropriateSvgRepresentation(decodeToPictureDrawable(bytes))
+    }
+
+    private fun getAppropriateSvgRepresentation(pictureDrawable: PictureDrawable?): ImageRepresentation<Any> {
+        return if (shouldBeRasterized) {
+            convertPictureDrawableToBitmap(pictureDrawable)
+        } else {
+            ImageRepresentation.PictureDrawable(pictureDrawable)
+        }
+    }
+
+    private fun convertPictureDrawableToBitmap(pictureDrawable: PictureDrawable?): ImageRepresentation<Bitmap> {
+        val bitmap = pictureDrawable?.toBitmap(pictureDrawable.intrinsicWidth, pictureDrawable.intrinsicHeight)
+        return ImageRepresentation.Bitmap(bitmap)
+    }
+
+    private fun decodeToBitmap(bytes: ByteArray): Bitmap? {
         val options = BitmapFactory.Options()
         options.inPreferredConfig = Bitmap.Config.ARGB_8888
         val bitmap = try {
             BitmapFactory.decodeByteArray(bytes, 0, bytes.size, options)
         } catch (e: IllegalArgumentException) {
             KLog.e("Div") { "Problem with decoding base-64 preview image occurred" }
-            return
+            return null
         }
-
-        if (synchronous) {
-            onDecoded(bitmap)
-        } else {
-            UiThreadHandler.postOnMainThread {
-                onDecoded(bitmap)
-            }
-        }
+        return bitmap
     }
 
-    private fun extractFromDataUrl(base64string: String): String {
-        // this is data-url format: data:[;base64],<data>
-        if (base64string.startsWith("data:")) {
+    private fun decodeToPictureDrawable(bytes: ByteArray): PictureDrawable? {
+        return svgDecoder.decode(bytes.inputStream())
+    }
+
+    private fun extractFormatFromDataUrlOrNull(base64string: String) : String? {
+        if (containsData(base64string)) {
+            return base64string.substring(base64string.indexOf('/') + 1, base64string.indexOf(';'))
+        }
+        return null
+    }
+
+    private fun extractDataFromDataUrl(base64string: String): String {
+        if (containsData(base64string)) {
             return base64string.substring(base64string.indexOf(',') + 1)
         }
         return base64string
+    }
+
+    private fun containsData(base64string: String): Boolean {
+        // this is data-url format: data:[;base64],<data>
+        return base64string.startsWith("data:")
     }
 }

--- a/client/android/div/src/main/java/com/yandex/div/core/DivConfiguration.java
+++ b/client/android/div/src/main/java/com/yandex/div/core/DivConfiguration.java
@@ -15,6 +15,7 @@ import com.yandex.div.core.images.DivImageLoader;
 import com.yandex.div.core.player.DivPlayerFactory;
 import com.yandex.div.core.player.DivPlayerPreloader;
 import com.yandex.div.core.state.DivStateChangeListener;
+import com.yandex.div.core.svg.SvgDivImageLoader;
 import com.yandex.div.core.view2.divs.widgets.DivRecyclerView;
 import com.yandex.div.internal.viewpool.ViewPoolProfiler;
 import com.yandex.div.internal.viewpool.ViewPreCreationProfile;
@@ -28,6 +29,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import kotlin.Lazy;
+
 /**
  * Holds {@link com.yandex.div.core.view2.Div2View} configuration.
  * Create instance using {@link Builder} class.
@@ -38,6 +41,8 @@ public class DivConfiguration {
 
     @NonNull
     private final DivImageLoader mImageLoader;
+    @NonNull
+    private final Lazy<SvgDivImageLoader> mSvgImageLoader;
     @NonNull
     private final DivActionHandler mActionHandler;
     @NonNull
@@ -103,6 +108,7 @@ public class DivConfiguration {
 
     private DivConfiguration(
             @NonNull DivImageLoader imageLoader,
+            @NonNull Lazy<SvgDivImageLoader> svgImageLoader,
             @NonNull DivActionHandler actionHandler,
             @NonNull Div2Logger div2Logger,
             @NonNull DivDataChangeListener divDataChangeListener,
@@ -141,6 +147,7 @@ public class DivConfiguration {
             float recyclerScrollInterceptionAngle
     ) {
         mImageLoader = imageLoader;
+        mSvgImageLoader = svgImageLoader;
         mActionHandler = actionHandler;
         mDiv2Logger = div2Logger;
         mDivDataChangeListener = divDataChangeListener;
@@ -190,6 +197,10 @@ public class DivConfiguration {
     public DivImageLoader getImageLoader() {
         return mImageLoader;
     }
+
+    @Provides
+    @NonNull
+    public Lazy<SvgDivImageLoader> getSvgImageLoader() { return mSvgImageLoader; }
 
     @Provides
     @NonNull
@@ -407,6 +418,8 @@ public class DivConfiguration {
 
         @NonNull
         private final DivImageLoader mImageLoader;
+        @NonNull
+        private final Lazy<SvgDivImageLoader> mSvgImageLoader;
         @Nullable
         private DivActionHandler mActionHandler;
         @Nullable
@@ -465,8 +478,12 @@ public class DivConfiguration {
         private boolean mComplexRebindEnabled = Experiment.COMPLEX_REBIND_ENABLED.getDefaultValue();
         private float mRecyclerScrollInterceptionAngle = DivRecyclerView.NOT_INTERCEPT;
 
-        public Builder(@NonNull DivImageLoader imageLoader) {
+        public Builder(
+            @NonNull DivImageLoader imageLoader,
+            @NonNull Lazy<SvgDivImageLoader> svgImageLoader
+        ) {
             mImageLoader = imageLoader;
+            mSvgImageLoader = svgImageLoader;
         }
 
         /**
@@ -728,6 +745,7 @@ public class DivConfiguration {
                     mTypefaceProvider == null ? DivTypefaceProvider.DEFAULT : mTypefaceProvider;
             return new DivConfiguration(
                     mImageLoader,
+                    mSvgImageLoader,
                     mActionHandler == null ? new DivActionHandler() : mActionHandler,
                     mDiv2Logger == null ? Div2Logger.STUB : mDiv2Logger,
                     mDivDataChangeListener == null ? DivDataChangeListener.STUB : mDivDataChangeListener,

--- a/client/android/div/src/main/java/com/yandex/div/core/DivPreloader.kt
+++ b/client/android/div/src/main/java/com/yandex/div/core/DivPreloader.kt
@@ -1,6 +1,7 @@
 package com.yandex.div.core
 
 import android.net.Uri
+import android.graphics.drawable.PictureDrawable
 import com.yandex.div.core.DivPreloader.Callback
 import com.yandex.div.core.DivPreloader.PreloadReference
 import com.yandex.div.core.annotations.Mockable
@@ -165,6 +166,10 @@ class DivPreloader internal constructor(
         }
 
         override fun onSuccess(cachedBitmap: CachedBitmap) {
+            done()
+        }
+
+        override fun onSuccess(pictureDrawable: PictureDrawable) {
             done()
         }
 

--- a/client/android/div/src/main/java/com/yandex/div/core/svg/FlexibleDivImageLoader.kt
+++ b/client/android/div/src/main/java/com/yandex/div/core/svg/FlexibleDivImageLoader.kt
@@ -1,0 +1,60 @@
+package com.yandex.div.core.svg
+
+import android.widget.ImageView
+import com.yandex.div.core.annotations.Mockable
+import com.yandex.div.core.images.DivImageDownloadCallback
+import com.yandex.div.core.images.DivImageLoader
+import com.yandex.div.core.images.LoadReference
+import javax.inject.Inject
+
+/**
+ * A wrapper over DivImageLoader.
+ * Replaces chosen image loader by SVG Image Loader if image loader doesn't support svg images.
+ */
+@Mockable
+class FlexibleDivImageLoader @Inject constructor(
+    private val providedImageLoader: DivImageLoader,
+    private val svgImageLoader: Lazy<SvgDivImageLoader>
+) : DivImageLoader {
+
+    override fun loadImage(imageUrl: String, callback: DivImageDownloadCallback): LoadReference {
+        val overriddenImageLoader = getSvgImageLoaderIfNeeded(imageUrl)
+        return overriddenImageLoader.loadImage(imageUrl, callback)
+    }
+
+    override fun loadImage(
+        imageUrl: String,
+        shouldBeRasterized: Boolean,
+        callback: DivImageDownloadCallback
+    ): LoadReference {
+        val overriddenImageLoader = getSvgImageLoaderIfNeeded(imageUrl)
+        return overriddenImageLoader.loadImage(imageUrl, shouldBeRasterized, callback)
+    }
+
+    override fun loadImage(imageUrl: String, imageView: ImageView): LoadReference {
+        val overriddenImageLoader = getSvgImageLoaderIfNeeded(imageUrl)
+        return overriddenImageLoader.loadImage(imageUrl, imageView)
+    }
+
+    override fun loadImageBytes(
+        imageUrl: String,
+        callback: DivImageDownloadCallback
+    ): LoadReference {
+        val overriddenImageLoader = getSvgImageLoaderIfNeeded(imageUrl)
+        return overriddenImageLoader.loadImageBytes(imageUrl, callback)
+    }
+
+    private fun getSvgImageLoaderIfNeeded(imageUrl: String) : DivImageLoader {
+        return if (shouldCreateSvgImageLoader(imageUrl)) svgImageLoader.value else providedImageLoader
+    }
+
+    private fun shouldCreateSvgImageLoader(imageUrl: String) : Boolean {
+        return isSvg(imageUrl) && !providedImageLoader.doesSupportSvg()
+    }
+
+    private fun isSvg(imageUrl: String): Boolean {
+        val queryStartIndex = imageUrl.indexOf('?')
+        val pathEndIndex = if (queryStartIndex == -1) imageUrl.length else queryStartIndex
+        return imageUrl.substring(0, pathEndIndex).endsWith(".svg")
+    }
+}

--- a/client/android/div/src/main/java/com/yandex/div/core/svg/SvgCacheManager.kt
+++ b/client/android/div/src/main/java/com/yandex/div/core/svg/SvgCacheManager.kt
@@ -1,0 +1,20 @@
+package com.yandex.div.core.svg
+
+import android.graphics.drawable.PictureDrawable
+import java.util.WeakHashMap
+
+/**
+ * A simple cache manager for storing downloaded svg images
+ */
+class SvgCacheManager {
+
+    private val cache = WeakHashMap<String, PictureDrawable>()
+
+    fun get(imageUrl: String) : PictureDrawable? {
+        return cache[imageUrl]
+    }
+
+    fun set(imageUrl: String, pictureDrawable: PictureDrawable) {
+        cache[imageUrl] = pictureDrawable
+    }
+}

--- a/client/android/div/src/main/java/com/yandex/div/core/svg/SvgDecoder.kt
+++ b/client/android/div/src/main/java/com/yandex/div/core/svg/SvgDecoder.kt
@@ -1,0 +1,36 @@
+package com.yandex.div.core.svg
+
+import android.graphics.RectF
+import android.graphics.drawable.PictureDrawable
+import com.caverock.androidsvg.SVG
+import com.caverock.androidsvg.SVGParseException
+import java.io.InputStream
+
+class SvgDecoder(
+    private val useViewBoundsAsIntrinsicSize: Boolean = true
+) {
+    fun decode(source: InputStream): PictureDrawable? {
+        return try {
+            val svg: SVG = SVG.getFromInputStream(source)
+
+            val svgWidth: Float
+            val svgHeight: Float
+            val viewBox: RectF? = svg.documentViewBox
+            if (useViewBoundsAsIntrinsicSize && viewBox != null) {
+                svgWidth = viewBox.width()
+                svgHeight = viewBox.height()
+            } else {
+                svgWidth = svg.documentWidth
+                svgHeight = svg.documentHeight
+            }
+
+            if (viewBox == null && svgWidth > 0 && svgHeight > 0) {
+                svg.setDocumentViewBox(0f, 0f, svgWidth, svgHeight)
+            }
+
+            return PictureDrawable(svg.renderToPicture())
+        } catch (ex: SVGParseException) {
+            return null // explicitly return null
+        }
+    }
+}

--- a/client/android/div/src/main/java/com/yandex/div/core/svg/SvgDivImageLoader.kt
+++ b/client/android/div/src/main/java/com/yandex/div/core/svg/SvgDivImageLoader.kt
@@ -1,0 +1,112 @@
+package com.yandex.div.core.svg
+
+import android.graphics.drawable.PictureDrawable
+import android.net.Uri
+import android.widget.ImageView
+import androidx.core.graphics.drawable.toBitmap
+import com.yandex.div.core.images.BitmapSource
+import com.yandex.div.core.images.CachedBitmap
+import com.yandex.div.core.images.DivImageDownloadCallback
+import com.yandex.div.core.images.DivImageLoader
+import com.yandex.div.core.images.LoadReference
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.Call
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+class SvgDivImageLoader : DivImageLoader {
+    private val httpClient = OkHttpClient.Builder().build()
+    private val coroutineScope = MainScope()
+    private val svgDecoder = SvgDecoder()
+    private val svgCacheManager = SvgCacheManager()
+    override fun doesSupportSvg(): Boolean {
+        return true
+    }
+
+    private fun createCall(imageUrl: String) : Call {
+        val request = Request.Builder().url(imageUrl).build()
+        return httpClient.newCall(request)
+    }
+
+    override fun loadImage(
+        imageUrl: String,
+        shouldBeRasterized: Boolean,
+        callback: DivImageDownloadCallback
+    ): LoadReference {
+        val call = createCall(imageUrl)
+
+        val pictureDrawable = svgCacheManager.get(imageUrl)
+        if (pictureDrawable != null) {
+            // If it's not possible to handle the image as a vector, convert it to bitmap
+            if (shouldBeRasterized) {
+                val bitmap = pictureDrawable!!.toCachedBitmap(imageUrl, BitmapSource.MEMORY)
+                callback.onSuccess(bitmap)
+            } else {
+                callback.onSuccess(pictureDrawable!!)
+            }
+            return LoadReference { }
+        }
+
+        coroutineScope.launch {
+            withContext(Dispatchers.IO) {
+                val response = runCatching {
+                    call.execute()
+                }.getOrNull() ?: return@withContext null
+                val source = response.cacheResponse?.let { BitmapSource.MEMORY } ?: BitmapSource.NETWORK
+                val bytes = response.body?.bytes() ?: return@withContext null
+                val pictureDrawable = svgDecoder.decode(bytes.inputStream()) ?: return@withContext null
+                svgCacheManager.set(imageUrl, pictureDrawable)
+
+                if (shouldBeRasterized) pictureDrawable.toCachedBitmap(imageUrl, source, bytes) else pictureDrawable
+            }?.let {
+                if (it is PictureDrawable) callback.onSuccess(it) else callback.onSuccess(it as CachedBitmap)
+            } ?: callback.onError()
+        }
+
+        return LoadReference {
+            call.cancel()
+        }
+    }
+
+    override fun loadImage(imageUrl: String, callback: DivImageDownloadCallback): LoadReference {
+        // By default, we assume svg images can be represented as vectors.
+        return loadImage(imageUrl, false, callback)
+    }
+
+    override fun loadImage(imageUrl: String, imageView: ImageView): LoadReference {
+        val call = createCall(imageUrl)
+
+        coroutineScope.launch {
+            withContext(Dispatchers.IO) {
+                val response = runCatching {
+                    call.execute()
+                }.getOrNull() ?: return@withContext null
+                val bytes = response.body?.bytes() ?: return@withContext null
+                svgDecoder.decode(bytes.inputStream())
+            }?.let {
+                imageView.setImageDrawable(it)
+            }
+        }
+
+        return LoadReference {
+            call.cancel()
+        }
+    }
+
+    override fun loadImageBytes(
+        imageUrl: String,
+        callback: DivImageDownloadCallback
+    ): LoadReference {
+        return LoadReference {
+            loadImage(imageUrl, callback)
+        }
+    }
+
+    private fun PictureDrawable.toCachedBitmap(imageUrl: String, source: BitmapSource, bytes: ByteArray? = null) : CachedBitmap {
+        val bitmap = toBitmap(intrinsicWidth, intrinsicHeight)
+        return CachedBitmap(bitmap, bytes, Uri.parse(imageUrl), source)
+    }
+}

--- a/client/android/div/src/main/java/com/yandex/div/core/util/ImageRepresentation.kt
+++ b/client/android/div/src/main/java/com/yandex/div/core/util/ImageRepresentation.kt
@@ -1,0 +1,10 @@
+package com.yandex.div.core.util
+
+/**
+ * Class to store either of two representations of the image.
+ * Bitmap for raster images, picture drawable for vector images.
+ */
+sealed class ImageRepresentation<out T> {
+    data class Bitmap<out Bitmap>(val value: Bitmap?) : ImageRepresentation<Bitmap>()
+    data class PictureDrawable<out PictureDrawable>(val value: PictureDrawable?) : ImageRepresentation<PictureDrawable>()
+}

--- a/client/android/div/src/main/java/com/yandex/div/core/view2/divs/DivGifImageBinder.kt
+++ b/client/android/div/src/main/java/com/yandex/div/core/view2/divs/DivGifImageBinder.kt
@@ -1,18 +1,19 @@
 package com.yandex.div.core.view2.divs
 
 import android.content.Context
+import android.graphics.Bitmap
 import android.graphics.ImageDecoder
 import android.graphics.drawable.AnimatedImageDrawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.PictureDrawable
-import android.graphics.drawable.ScaleDrawable
 import android.os.AsyncTask
 import android.os.Build
 import androidx.annotation.RequiresApi
 import com.yandex.div.core.DivIdLoggingImageDownloadCallback
 import com.yandex.div.core.dagger.DivScope
 import com.yandex.div.core.images.CachedBitmap
-import com.yandex.div.core.images.DivImageLoader
+import com.yandex.div.core.svg.FlexibleDivImageLoader
+import com.yandex.div.core.util.ImageRepresentation
 import com.yandex.div.core.view2.Div2View
 import com.yandex.div.core.view2.DivPlaceholderLoader
 import com.yandex.div.core.view2.DivViewBinder
@@ -37,7 +38,7 @@ private const val GIF_SUFFIX = ".gif"
 @DivScope
 internal class DivGifImageBinder @Inject constructor(
     private val baseBinder: DivBaseBinder,
-    private val imageLoader: DivImageLoader,
+    private val imageLoader: FlexibleDivImageLoader,
     private val placeholderLoader: DivPlaceholderLoader,
     private val errorCollectors: ErrorCollectors,
 ) : DivViewBinder<DivGifImage, DivGifImageView> {
@@ -111,7 +112,14 @@ internal class DivGifImageBinder @Inject constructor(
             },
             onSetPreview = {
                 if (!isImageLoaded) {
-                    setPreview(it)
+                    when (it) {
+                        is ImageRepresentation.Bitmap -> {
+                            setPreview(it.value as Bitmap)
+                        }
+                        is ImageRepresentation.PictureDrawable -> {
+                            setPreview(it.value as PictureDrawable)
+                        }
+                    }
                     previewLoaded()
                 }
             }

--- a/client/android/div/src/test/java/com/yandex/div/core/view2/Div2ApplyPatchTest.kt
+++ b/client/android/div/src/test/java/com/yandex/div/core/view2/Div2ApplyPatchTest.kt
@@ -8,6 +8,7 @@ import com.yandex.div.DivDataTag
 import com.yandex.div.core.Div2Context
 import com.yandex.div.core.DivConfiguration
 import com.yandex.div.core.images.DivImageLoader
+import com.yandex.div.core.svg.SvgDivImageLoader
 import com.yandex.div.core.view2.divs.UnitTestData
 import com.yandex.div.core.viewEquals
 import com.yandex.div.internal.Assert
@@ -24,10 +25,10 @@ class Div2ApplyPatchTest {
     private val divImageLoader = mock<DivImageLoader>()
     private val controller = Robolectric.buildActivity(Activity::class.java)
     private val activity = controller.get()
-
+    private val svgDivImageLoader = mock<Lazy<SvgDivImageLoader>>()
     private val div2Context = Div2Context(
         activity,
-        DivConfiguration.Builder(divImageLoader).build()
+        DivConfiguration.Builder(divImageLoader, svgDivImageLoader).build()
     )
 
     private val div2View = Div2View(div2Context)

--- a/client/android/div/src/test/java/com/yandex/div/core/view2/Div2RebindTest.kt
+++ b/client/android/div/src/test/java/com/yandex/div/core/view2/Div2RebindTest.kt
@@ -8,6 +8,7 @@ import com.yandex.div.core.DivConfiguration
 import com.yandex.div.core.images.DivImageLoader
 import com.yandex.div.core.state.DivPathUtils.findStateLayout
 import com.yandex.div.core.state.DivStatePath
+import com.yandex.div.core.svg.SvgDivImageLoader
 import com.yandex.div.core.view2.divs.CONTAINER_DIR
 import com.yandex.div.core.view2.divs.UnitTestData
 import com.yandex.div.core.view2.divs.widgets.DivStateLayout
@@ -26,11 +27,12 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class Div2RebindTest {
     private val divImageLoader = mock<DivImageLoader>()
+    private val svgDivImageLoader = mock<Lazy<SvgDivImageLoader>>()
     private val activity = Robolectric.buildActivity(Activity::class.java).get()
     private val testData = UnitTestData("div-state", "state_tree.json")
     private val div2Context = Div2Context(
         activity,
-        DivConfiguration.Builder(divImageLoader).build()
+        DivConfiguration.Builder(divImageLoader, svgDivImageLoader).build()
     )
 
     private val div2View = Div2View(div2Context)

--- a/client/android/div/src/test/java/com/yandex/div/core/view2/Div2ViewReleaseChildrenTest.kt
+++ b/client/android/div/src/test/java/com/yandex/div/core/view2/Div2ViewReleaseChildrenTest.kt
@@ -37,7 +37,7 @@ class Div2ViewReleaseChildrenTest {
     private val activity = Robolectric.buildActivity(Activity::class.java).get()
     private val backingContext = Div2Context(
         baseContext = activity,
-        configuration = DivConfiguration.Builder(mock()).build()
+        configuration = DivConfiguration.Builder(mock(), mock()).build()
     )
     private val viewBinder = mock<DivBinder>()
     private val divExtensionController = DivExtensionController(emptyList())

--- a/client/android/div/src/test/java/com/yandex/div/core/view2/Div2ViewTest.kt
+++ b/client/android/div/src/test/java/com/yandex/div/core/view2/Div2ViewTest.kt
@@ -9,6 +9,7 @@ import com.yandex.div.core.TestViewComponentBuilder
 import com.yandex.div.core.childrenToFlatList
 import com.yandex.div.core.images.DivImageLoader
 import com.yandex.div.core.path
+import com.yandex.div.core.svg.SvgDivImageLoader
 import com.yandex.div.core.view2.animations.DIV_STATE_DIR
 import com.yandex.div.core.view2.divs.UnitTestData
 import com.yandex.div.core.view2.state.DivStateSwitcher
@@ -28,10 +29,11 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class Div2ViewTest {
     private val divImageLoader = mock<DivImageLoader>()
+    private val svgDivImageLoader = mock<Lazy<SvgDivImageLoader>>()
     private val activity = Robolectric.buildActivity(Activity::class.java).get()
     private val backingContext = Div2Context(
         baseContext = activity,
-        configuration = DivConfiguration.Builder(divImageLoader).build()
+        configuration = DivConfiguration.Builder(divImageLoader, svgDivImageLoader).build()
     )
     private val stateSwitcher = mock<DivStateSwitcher>()
     private val component = TestComponent(

--- a/client/android/div/src/test/java/com/yandex/div/core/view2/GlobalVariableScopesTest.kt
+++ b/client/android/div/src/test/java/com/yandex/div/core/view2/GlobalVariableScopesTest.kt
@@ -8,6 +8,7 @@ import com.yandex.div.core.TestComponent
 import com.yandex.div.core.TestViewComponentBuilder
 import com.yandex.div.core.expression.variables.GlobalVariableController
 import com.yandex.div.core.images.DivImageLoader
+import com.yandex.div.core.svg.SvgDivImageLoader
 import com.yandex.div.core.view2.state.DivStateSwitcher
 import com.yandex.div.data.DivParsingEnvironment
 import com.yandex.div.data.Variable
@@ -17,6 +18,7 @@ import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.spy
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 
@@ -51,10 +53,11 @@ class GlobalVariableScopesTest {
         }
 
         private val divImageLoader = mock<DivImageLoader>()
+        private val svgDivImageLoader = mock<Lazy<SvgDivImageLoader>>()
         private val activity = Robolectric.buildActivity(Activity::class.java).get()
         private val div2Context = Div2Context(
                 baseContext = activity,
-                configuration = DivConfiguration.Builder(divImageLoader)
+                configuration = DivConfiguration.Builder(divImageLoader, svgDivImageLoader)
                         .globalVariableController(variableController)
                         .build()
         )

--- a/client/android/div/src/test/java/com/yandex/div/core/view2/divs/DivBinderTest.kt
+++ b/client/android/div/src/test/java/com/yandex/div/core/view2/divs/DivBinderTest.kt
@@ -8,6 +8,7 @@ import com.yandex.div.core.dagger.Div2Component
 import com.yandex.div.core.dagger.Div2ViewComponent
 import com.yandex.div.core.extension.DivExtensionController
 import com.yandex.div.core.images.DivImageLoader
+import com.yandex.div.core.svg.FlexibleDivImageLoader
 import com.yandex.div.core.view2.Div2View
 import com.yandex.div.core.view2.DivTransitionBuilder
 import com.yandex.div.core.view2.DivValidator
@@ -40,6 +41,7 @@ open class DivBinderTest {
         on { validate(any(), any()) } doReturn true
     }
     internal val imageLoader = mock<DivImageLoader>()
+    internal val flexibleImageLoader = mock<FlexibleDivImageLoader>()
 
     internal val context = RuntimeEnvironment.application
     private val expressionResolver = mock<ExpressionResolver>()

--- a/client/android/div/src/test/java/com/yandex/div/core/view2/divs/DivViewMocks.kt
+++ b/client/android/div/src/test/java/com/yandex/div/core/view2/divs/DivViewMocks.kt
@@ -32,7 +32,7 @@ internal fun divView(
     val context = context()
     val div2Context = Div2Context(
         ContextThemeWrapper(context, context.theme),
-        DivConfiguration.Builder(mock()).build(),
+        DivConfiguration.Builder(mock(), mock()).build(),
         lifecycleOwner = null
     )
 

--- a/client/android/div/src/test/java/com/yandex/div/core/view2/state/DivJoinedStateSwitcherTest.kt
+++ b/client/android/div/src/test/java/com/yandex/div/core/view2/state/DivJoinedStateSwitcherTest.kt
@@ -31,7 +31,7 @@ class DivJoinedStateSwitcherTest {
     private val viewBinder = mock<DivBinder>()
     private val div2Context = Div2Context(
         baseContext = activity,
-        configuration = DivConfiguration.Builder(mock()).build()
+        configuration = DivConfiguration.Builder(mock(), mock()).build()
     )
     private val div2View = Div2View(div2Context).apply {
         setData(

--- a/client/android/div/src/test/java/com/yandex/div/core/view2/state/DivMultipleStateSwitcherTest.kt
+++ b/client/android/div/src/test/java/com/yandex/div/core/view2/state/DivMultipleStateSwitcherTest.kt
@@ -34,7 +34,7 @@ class DivMultipleStateSwitcherTest {
     private val activity = Robolectric.buildActivity(Activity::class.java).get()
     private val div2Context = Div2Context(
         baseContext = activity,
-        configuration = DivConfiguration.Builder(mock())
+        configuration = DivConfiguration.Builder(mock(), mock())
             .build()
     )
     private val divView = Div2View(div2Context).apply {

--- a/client/android/divkit-demo-app/src/main/java/com/yandex/divkit/demo/div/DivUtils.kt
+++ b/client/android/divkit-demo-app/src/main/java/com/yandex/divkit/demo/div/DivUtils.kt
@@ -9,6 +9,7 @@ import com.yandex.div.core.DivActionHandler
 import com.yandex.div.core.DivConfiguration
 import com.yandex.div.core.DivViewFacade
 import com.yandex.div.core.experiments.Experiment
+import com.yandex.div.core.svg.SvgDivImageLoader
 import com.yandex.div.data.DivParsingEnvironment
 import com.yandex.div.font.YandexSansDisplayDivTypefaceProvider
 import com.yandex.div.font.YandexSansDivTypefaceProvider
@@ -40,7 +41,7 @@ fun divConfiguration(
 ): DivConfiguration.Builder {
     val reporter = MetricaUtils.getReporter(activity)
     val flagPreferenceProvider = Container.flagPreferenceProvider
-    return DivConfiguration.Builder(Container.imageLoader)
+    return DivConfiguration.Builder(Container.imageLoader, lazyOf(SvgDivImageLoader()))
         .actionHandler(DemoDivActionHandler(Container.uriHandler.apply { handlingActivity = activity }))
         .divCustomViewFactory(DemoDivCustomViewFactory())
         .divCustomContainerViewAdapter(DemoDivCustomViewAdapter(activity, Container.videoCustomViewController))

--- a/client/android/glide/src/main/java/com/yandex/div/glide/GlideDivImageLoader.kt
+++ b/client/android/glide/src/main/java/com/yandex/div/glide/GlideDivImageLoader.kt
@@ -24,6 +24,10 @@ class GlideDivImageLoader(
     private val context: Context
 ) : DivImageLoader {
 
+    override fun doesSupportSvg(): Boolean {
+        return false
+    }
+
     override fun loadImage(imageUrl: String, callback: DivImageDownloadCallback): LoadReference {
         val imageUri = Uri.parse(imageUrl)
         // create target to be able to cancel loading
@@ -47,7 +51,6 @@ class GlideDivImageLoader(
         val imageUri = Uri.parse(imageUrl)
 
         Glide.with(context).asBitmap().load(imageUri).into(imageView)
-
         return LoadReference {
             Glide.with(context).clear(imageView)
         }
@@ -60,7 +63,6 @@ class GlideDivImageLoader(
             override fun onResourceReady(resource: GifDrawable, transition: Transition<in GifDrawable>?) { }
             override fun onLoadCleared(placeholder: Drawable?) { }
         }
-
         // load result will be handled by RequestListener to get dataSource
         Glide.with(context).asGif().listener(GifImageRequestListener(callback, imageUri)).load(imageUri).into(target)
 

--- a/client/android/picasso/src/main/java/com/yandex/div/picasso/PicassoDivImageLoader.kt
+++ b/client/android/picasso/src/main/java/com/yandex/div/picasso/PicassoDivImageLoader.kt
@@ -48,6 +48,10 @@ class PicassoDivImageLoader(
             .build()
     }
 
+    override fun doesSupportSvg(): Boolean {
+        return false
+    }
+
     override fun loadImage(imageUrl: String, callback: DivImageDownloadCallback): LoadReference {
         val imageUri = Uri.parse(imageUrl)
         val target = DownloadCallbackAdapter(imageUri, callback)

--- a/test_data/regression_test_data/div_background_vector.json
+++ b/test_data/regression_test_data/div_background_vector.json
@@ -1,0 +1,79 @@
+{
+  "templates": {
+    "text_block": {
+      "type": "text",
+      "text_color": "#FFA500",
+      "height": {
+        "type": "fixed",
+        "value": 184
+      },
+      "paddings": {
+        "left": 16,
+        "right": 16,
+        "bottom": 16
+      },
+      "margins": {
+        "left": 24,
+        "right": 24,
+        "bottom": 16
+      },
+      "text_alignment_vertical": "bottom",
+      "font_size": 18,
+      "line_height": 20
+    }
+  },
+  "card": {
+    "log_id": "snapshot_test_card",
+    "states": [
+      {
+        "state_id": 0,
+        "div": {
+          "type": "container",
+          "orientation": "vertical",
+          "margins": {
+            "top": 24
+          },
+          "items": [
+            {
+              "type": "text_block",
+              "background": [
+                {
+                  "type": "image",
+                  "image_url": "https://yastatic.net/s3/home/divkit/svg-test-image.svg"
+                }
+              ],
+              "text": "Svg background (picture drawable)"
+            },
+            {
+              "type": "text_block",
+              "background": [
+                {
+                  "type": "image",
+                  "image_url": "https://yastatic.net/s3/home/divkit/svg-test-image.svg",
+                  "alpha": 0.5
+                }
+              ],
+              "text": "Transparent svg background (bitmap)"
+            },
+            {
+              "type": "text_block",
+              "background": [
+                {
+                  "type": "image",
+                  "image_url": "https://yastatic.net/s3/home/divkit/svg-test-image.svg",
+                  "filters": [
+                    {
+                      "type": "blur",
+                      "radius": 5
+                    }
+                  ]
+                }
+              ],
+              "text": "Blurred svg background (bitmap)"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/test_data/regression_test_data/div_image_vector.json
+++ b/test_data/regression_test_data/div_image_vector.json
@@ -1,0 +1,87 @@
+{
+  "templates": {
+    "svg_card": {
+      "type": "image",
+      "image_url": "https://yastatic.net/s3/home/divkit/svg-test-image.svg",
+      "height": {
+        "type": "fixed",
+        "value": 150
+      },
+      "width": {
+        "type": "fixed",
+        "value": 150
+      },
+      "margins": {
+        "left": 10,
+        "top": 20,
+        "right": 10,
+        "bottom": 10
+      },
+      "alignment_horizontal": "center"
+    },
+    "svg_card_text": {
+      "type": "text",
+      "text_alignment_horizontal": "center",
+      "font_size": 18
+    }
+  },
+  "card": {
+    "log_id": "snapshot_test_card",
+    "states": [
+      {
+        "state_id": 0,
+        "div": {
+          "type": "container",
+          "orientation": "vertical",
+          "items": [
+            {
+              "type": "svg_card"
+            },
+            {
+              "type": "svg_card_text",
+              "text": "Svg image (picture drawable)"
+            },
+            {
+              "type": "svg_card",
+              "alpha": 0.5
+            },
+            {
+              "type": "svg_card_text",
+              "text": "Transparent svg image (picture drawable)"
+            },
+            {
+              "type": "svg_card",
+              "image_url": "https://yastatic.net/s3/home/divkit/svg-test-image123.svg",
+              "preview": "data:image/svg;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gVXBsb2FkZWQgdG86IFNWRyBSZXBvLCB3d3cuc3ZncmVwby5jb20sIEdlbmVyYXRvcjogU1ZHIFJlcG8gTWl4ZXIgVG9vbHMgLS0+DQo8c3ZnIHdpZHRoPSI4MDBweCIgaGVpZ2h0PSI4MDBweCIgdmlld0JveD0iMCAwIDEwMjQgMTAyNCIgY2xhc3M9Imljb24iICB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0iTTUxMiA5NjBjLTkyLjggMC0xNjAtMjAwLTE2MC00NDhTNDE5LjIgNjQgNTEyIDY0czE2MCAyMDAgMTYwIDQ0OC02Ny4yIDQ0OC0xNjAgNDQ4eiBtMC0zMmM2NS42IDAgMTI4LTE4NS42IDEyOC00MTZTNTc3LjYgOTYgNTEyIDk2cy0xMjggMTg1LjYtMTI4IDQxNiA2Mi40IDQxNiAxMjggNDE2eiIgZmlsbD0iIzA1MEQ0MiIgLz48cGF0aCBkPSJNMTI0LjggNzM2Yy00OC04MCA5Mi44LTIzOC40IDMwNy4yLTM2My4yUzg1Mi44IDIwOCA4OTkuMiAyODggODA2LjQgNTI2LjQgNTkyIDY1MS4yIDE3MS4yIDgxNiAxMjQuOCA3MzZ6IG0yNy4yLTE2YzMzLjYgNTcuNiAyMjUuNiAxNy42IDQyNC05Ny42UzkwNS42IDM2MS42IDg3MiAzMDQgNjQ2LjQgMjg2LjQgNDQ4IDQwMS42IDExOC40IDY2Mi40IDE1MiA3MjB6IiBmaWxsPSIjMDUwRDQyIiAvPjxwYXRoIGQ9Ik04OTkuMiA3MzZjLTQ2LjQgODAtMjU0LjQgMzguNC00NjcuMi04NC44Uzc2LjggMzY4IDEyNC44IDI4OHMyNTQuNC0zOC40IDQ2Ny4yIDg0LjhTOTQ3LjIgNjU2IDg5OS4yIDczNnogbS0yNy4yLTE2YzMzLjYtNTcuNi05Ny42LTIwMy4yLTI5Ni0zMTguNFMxODQgMjQ2LjQgMTUyIDMwNCAyNDkuNiA1MDcuMiA0NDggNjIyLjRzMzkyIDE1NS4yIDQyNCA5Ny42eiIgZmlsbD0iIzA1MEQ0MiIgLz48cGF0aCBkPSJNNTEyIDU5MmMtNDQuOCAwLTgwLTM1LjItODAtODBzMzUuMi04MCA4MC04MCA4MCAzNS4yIDgwIDgwLTM1LjIgODAtODAgODB6TTI3MiAzMTJjLTI3LjIgMC00OC0yMC44LTQ4LTQ4czIwLjgtNDggNDgtNDggNDggMjAuOCA0OCA0OC0yMC44IDQ4LTQ4IDQ4ek00MTYgODgwYy0yNy4yIDAtNDgtMjAuOC00OC00OHMyMC44LTQ4IDQ4LTQ4IDQ4IDIwLjggNDggNDgtMjAuOCA0OC00OCA0OHogbTQ0OC00MzJjLTI3LjIgMC00OC0yMC44LTQ4LTQ4czIwLjgtNDggNDgtNDggNDggMjAuOCA0OCA0OC0yMC44IDQ4LTQ4IDQ4eiIgZmlsbD0iIzJGNEJGRiIgLz48L3N2Zz4="
+            },
+            {
+              "type": "svg_card_text",
+              "text": "Preview svg image (picture drawable)"
+            },
+            {
+              "type": "svg_card",
+              "filters": [
+                {
+                  "type": "blur",
+                  "radius": 5
+                }
+              ]
+            },
+            {
+              "type": "svg_card_text",
+              "text": "Blurred svg image (bitmap)"
+            },
+            {
+              "type": "svg_card",
+              "tint_color": "#00FF00"
+            },
+            {
+              "type": "svg_card_text",
+              "text": "Colored svg image (bitmap)"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/test_data/regression_test_data/index.json
+++ b/test_data/regression_test_data/index.json
@@ -1377,6 +1377,42 @@
       "file": "variables/div_variable_trigger_loops.json"
     },
     {
+      "title": "Vector images",
+      "tags": [
+        "Vector",
+        "Vector_images",
+        "Svg"
+      ],
+      "steps": [
+        "Look at the images"
+      ],
+      "expected_results": [
+        "The first image should be a simple image with no effects in black and blue colors.",
+        "The second image should be transparent in black and blue colors.",
+        "The third image should be a simple image with no effects in black and blue colors.",
+        "The fourth image should have a blur effect in black and blue colors.",
+        "The fifth image should be in green color."
+      ],
+      "file": "div_image_vector.json"
+    },
+    {
+      "title": "Vector background images",
+      "tags": [
+        "Vector",
+        "Vector_background_images",
+        "Svg"
+      ],
+      "steps": [
+        "Look at the images"
+      ],
+      "expected_results": [
+        "The first image should be a simple background image with no effects in black and blue colors.",
+        "The second image should be transparent in black and blue colors.",
+        "The third image should have a blur effect in black and blue colors."
+      ],
+      "file": "div_background_vector.json"
+    },
+    {
       "title": "Sequential animations",
       "steps": [
         "Click on image"

--- a/test_data/samples/image/svg.json
+++ b/test_data/samples/image/svg.json
@@ -1,0 +1,183 @@
+{
+  "templates": {
+    "title": {
+      "type": "text",
+      "font_size": 20,
+      "line_height": 24,
+      "font_weight": "bold",
+      "paddings": {
+        "left": 24,
+        "right": 24,
+        "bottom": 16
+      }
+    },
+    "subtitle": {
+      "font_size": 15,
+      "line_height": 20,
+      "type": "text",
+      "paddings": {
+        "left": 24,
+        "right": 24
+      }
+    }
+  },
+  "card": {
+    "log_id": "sample_card",
+    "variables": [
+      {
+        "name": "text_alpha",
+        "type": "number",
+        "value": 0.5
+      },
+      {
+        "name": "my_thumb_value",
+        "type": "integer",
+        "value": 0
+      }
+    ],
+    "variable_triggers": [
+      {
+        "condition": "@{my_thumb_value >= 0}",
+        "mode": "on_variable",
+        "actions": [
+          {
+            "log_id": "change_text_alpha",
+            "url": "div-action://set_variable?name=text_alpha&value=@{my_thumb_value}"
+          }
+        ]
+      }
+    ],
+    "states": [
+      {
+        "state_id": 0,
+        "div": {
+          "type": "container",
+          "orientation": "vertical",
+          "margins": {
+            "top": 24,
+            "bottom": 24
+          },
+          "items": [
+            {
+              "type": "title",
+              "text": "Vector Images"
+            },
+            {
+              "type": "subtitle",
+              "text": "Vector images are supported which can be scaled without loss of quality.\n\nThe top picture is in scalar format, while the bottom one is a vector.",
+              "margins": {
+                "bottom": 16
+              }
+            },
+            {
+              "type": "slider",
+              "width": {
+                "type": "match_parent"
+              },
+              "margins": {
+                "top": 16,
+                "left": 12,
+                "right": 12
+              },
+              "max_value": 400,
+              "min_value": 0,
+              "thumb_value_variable": "my_thumb_value",
+              "thumb_style": {
+                "type": "shape_drawable",
+                "color": "#FFCC00",
+                "stroke": {
+                  "color": "#ffffff",
+                  "width": 3
+                },
+                "shape": {
+                  "type": "rounded_rectangle",
+                  "item_height": {
+                    "type": "fixed",
+                    "value": 32
+                  },
+                  "item_width": {
+                    "type": "fixed",
+                    "value": 32
+                  },
+                  "corner_radius": {
+                    "type": "fixed",
+                    "value": 100
+                  }
+                }
+              },
+              "track_active_style": {
+                "type": "shape_drawable",
+                "color": "#FFCC00",
+                "shape": {
+                  "type": "rounded_rectangle",
+                  "item_height": {
+                    "type": "fixed",
+                    "value": 6
+                  }
+                }
+              },
+              "track_inactive_style": {
+                "type": "shape_drawable",
+                "color": "#20000000",
+                "shape": {
+                  "type": "rounded_rectangle",
+                  "item_height": {
+                    "type": "fixed",
+                    "value": 6
+                  }
+                }
+              }
+            },
+            {
+              "type": "subtitle",
+              "text": "Change size of images",
+              "margins": {
+                "top": 8,
+                "bottom": 16
+              },
+              "text_alignment_horizontal": "center"
+            },
+            {
+              "type": "container",
+              "items": [
+                {
+                  "type": "image",
+                  "image_url": "https://yastatic.net/s3/home/divkit/svg-test-image.png",
+                  "width": {
+                    "type": "fixed",
+                    "value": "@{my_thumb_value}"
+                  },
+                  "height": {
+                    "type": "fixed",
+                    "value": "@{my_thumb_value}"
+                  },
+                  "alignment_horizontal": "center",
+                  "alignment_vertical": "center"
+                }
+              ]
+            },
+            {
+              "type": "container",
+              "items": [
+                {
+                  "type": "image",
+                  "image_url": "https://yastatic.net/s3/home/divkit/svg-test-image.svg",
+                  "width": {
+                    "type": "fixed",
+                    "value": "@{my_thumb_value}"
+                  },
+                  "height": {
+                    "type": "fixed",
+                    "value": "@{my_thumb_value}"
+                  },
+                  "alignment_horizontal": "center",
+                  "alignment_vertical": "center"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: [link](https://yandex.ru/legal/cla/?lang=en)

### Notes
This pull request contains the changes that support loading images in SVG format.

1. SVG Image Loading
  * To load SVG images, a separate image loader is created;
  * [AndroidSVG](https://bigbadaboom.github.io/androidsvg/) library was used to decode SVG format;
  * A simple in-memory cache was implemented to store downloaded vector images locally;
  * Inside the app, vector images are represented in the format of PictureDrawable;
  * To render SVG, a new `onSuccess(PictureDrawable)` method was added in the `DivImageDownloadCallback` interface.

2. Picasso and Glide backward compatibility
  * The interface of DivImageLoader has been extended to have `doesSupportSvg()` method indicating whether the image loader supports SVG;
  * To make Picasso and Glide work with SVG images, a special `FlexibleImageLoader` bean was created;
  * It represents a wrapper over the standard image loader which can replace it with the SvgImageLoader under the hood if SVG format is not supported by the chosen image loader;

3. Rendering Vector Images
  * Vector images are being rendered inside of `onSuccess(PictureDrawable)` method in a similar way as bitmaps;
  * Images in vector format don't support tints and filters. To overcome this, DivImage `shouldBeRasterized` property was created which is being set to true if the tint or filters are overridden for the image;
  * If it should be rasterized, then that image is converted into bitmap of the size of the original SVG;
  * Background images don't support transparency and filters. When such properties are specified, then background image is converted to bitmap in a similar way.

4. Previews
  * To decode SVG images from base64, `DecodeBase64ImageTask` was extended to work with both formats;
  * Instead of working only with Bitmaps, it now supports Bitmap and PictureDrawable which are aggregated under a newly created `ImageRepresentation` sealed template class.

5. Samples and Testing Screens Updates
  * To demonstrate the features of vector images, `Sample` and `Testing` screens were updated accordingly.

<img src="https://github.com/divkit/divkit/assets/50011154/e8556b2c-e75a-4cf0-8cba-1ed9698ac905" width="250" height="525">

<img src="https://github.com/divkit/divkit/assets/50011154/599cf419-5eda-4b24-b04d-1a80f820f887" width="250" height="525">

<img src="https://github.com/divkit/divkit/assets/50011154/580aa030-8113-4808-a36c-8c12326cfc70" width="250" height="525">


