### PR TITLE
Request to make build Android client on Windows possible

### DIFF
--- a/api_generator/api_generator.bat
+++ b/api_generator/api_generator.bat
@@ -18,4 +18,4 @@ if "%5" neq "" (
 )
 
 echo Executing api_generator with [config = !config!] [schemaDir = !schemaDir!] [outputDir = !outputDir!] [optionalArgs = !optionalArgs!]
-python3 -u -m api_generator -c !config! -s !schemaDir! -o !outputDir! !optionalArgs!
+python -u -m api_generator -c !config! -s !schemaDir! -o !outputDir! !optionalArgs!

--- a/api_generator/api_generator.bat
+++ b/api_generator/api_generator.bat
@@ -1,0 +1,21 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set "scriptDir=%~dp0"
+cd /d "%scriptDir%"
+
+set "config=%1"
+set "schemaDir=%2"
+set "outputDir=%3"
+
+set "optionalArgs="
+if "%4" neq "" (
+  set "optionalArgs=!optionalArgs! %4"
+)
+
+if "%5" neq "" (
+  set "optionalArgs=!optionalArgs! %5"
+)
+
+echo Executing api_generator with [config = !config!] [schemaDir = !schemaDir!] [outputDir = !outputDir!] [optionalArgs = !optionalArgs!]
+python3 -u -m api_generator -c !config! -s !schemaDir! -o !outputDir! !optionalArgs!

--- a/api_generator/api_generator/schema/preprocessing/preprocessor.py
+++ b/api_generator/api_generator/schema/preprocessing/preprocessor.py
@@ -194,7 +194,7 @@ def internal_resolve_structure(
     if os.path.isdir(path):
         return entities.SchemaDirectory(path, parent_dir, lang)
 
-    with open(path, 'r') as file:
+    with open(path, 'r', encoding='utf-8') as file:
         json_data = json.loads(file.read())
         file.close()
 

--- a/client/android/api-generator-test/build.gradle.kts
+++ b/client/android/api-generator-test/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.android.build.gradle.internal.tasks.factory.dependsOn
+import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
     id("com.android.library")
@@ -36,7 +37,7 @@ android {
     defaultConfig {
         minSdk = rootProject.ext["minSdkVersion"] as Int
         targetSdk = rootProject.ext["targetSdkVersion"] as Int
-        buildConfigField("String", "TEMPLATES_JSON_PATH", "\"$testDataPath\"")
+        buildConfigField("String", "TEMPLATES_JSON_PATH", "\"${fixPath(testDataPath)}\"")
     }
 
     project.tasks.preBuild.dependsOn("generateHomePojoTask")
@@ -76,7 +77,7 @@ schemes.forEach { item ->
         val schemesDirectory = (item["scheme"] as File).absolutePath
         val generatedDir = item["generated"] as String
         val configPath = (item["config"] as File).absolutePath
-        val binPath = File(divKitPublicDir, "api_generator/api_generator.sh").absolutePath
+        val binPath = File(divKitPublicDir, "api_generator/api_generator.${getScriptExt()}").absolutePath
 
         commandLine = listOf(binPath, configPath, schemesDirectory, generatedDir)
 
@@ -95,4 +96,16 @@ tasks.register("generateHomePojoTask") {
     dependsOn(provider {
         tasks.filter { task -> task.name.startsWith("scheme_") }
     })
+}
+
+fun getScriptExt(): String {
+    return if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        "bat"
+    } else {
+        "sh"
+    }
+}
+
+fun fixPath(path: String): String {
+    return path.replace("\\", "/")
 }

--- a/client/android/div-data/build.gradle
+++ b/client/android/div-data/build.gradle
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+
 apply from: "${project.projectDir}/../div-library.gradle"
 apply from: "${project.projectDir}/../div-tests.gradle"
 apply from: "${project.projectDir}/../publish-android.gradle"
@@ -37,7 +39,7 @@ dependencies {
 }
 
 task generateDivModel(type: Exec) {
-    def execPath = new File(projectDir, '../../../api_generator/api_generator.sh').absolutePath
+    def execPath = new File(projectDir, "../../../api_generator/api_generator.${getScriptExt()}").absolutePath
     def configPath = new File(projectDir, 'div2-generator-config.json').absolutePath
     def schemaPath = new File(projectDir, "../../../schema").absolutePath
     def modelPath = new File(generatedSrcDir, "com/yandex/div2")
@@ -55,7 +57,7 @@ task generateDivModel(type: Exec) {
 }
 
 task generateDivSharedData(type: Exec) {
-    def execPath = new File(projectDir, '../../../api_generator/api_generator.sh').absolutePath
+    def execPath = new File(projectDir, "../../../api_generator/api_generator.${getScriptExt()}").absolutePath
     def sharedDataConfigPath = new File(projectDir, 'div2-shared-data-generator-config.json').absolutePath
     def sharedDataPath = new File(projectDir, "../../../shared_data").absolutePath
     def modelPath = new File(generatedSrcSharedDataDir, "com/yandex/div2")
@@ -76,5 +78,13 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
         freeCompilerArgs += '-opt-in=kotlin.RequiresOptIn'
         freeCompilerArgs += '-opt-in=com.yandex.div.data.DivModelInternalApi'
+    }
+}
+
+static def getScriptExt() {
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        return 'bat'
+    } else {
+        return 'sh'
     }
 }

--- a/client/android/div/build.gradle
+++ b/client/android/div/build.gradle
@@ -13,7 +13,7 @@ android {
     buildFeatures { buildConfig = true }
 
     defaultConfig {
-        buildConfigField "String", "DIV2_JSON_PATH", "\"$crossplatformProjectDir/\""
+        buildConfigField "String", "DIV2_JSON_PATH", "\"${fixPath(crossplatformProjectDir)}/\""
         buildConfigField "String", "VERSION_NAME", "\"${rootProject.property('divkitVersionName')}\""
     }
 }
@@ -53,4 +53,8 @@ dependencies {
 
     testImplementation "androidx.test:core-ktx:$versions.androidx.test"
     testImplementation "org.json:json:$versions.json"
+}
+
+static def fixPath(String path) {
+    return path.replace("\\", "/")
 }


### PR DESCRIPTION
Spent few hours trying to build divkit/client/android on my Windows 11 machine. Finally made demo app run. Is windows support not considered or I misunderstood something?

This PR is not necessarily the best way to go (it's just enough to make it run), maybe use it as a starting point?

Encountered problems:
* Shell script `api_generator.sh` (won't run via WSL/bash.exe as well)
* Windows specific is to have backslash as separator in a path, which breaks strings in generated BuildConfig.
* Python tried to use cp1251 encoding by default.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru