### PR TITLE
Added nested ternary operator test case

### DIFF
--- a/test_data/expression_test_data/operations_ternary.json
+++ b/test_data/expression_test_data/operations_ternary.json
@@ -149,6 +149,29 @@
                 "web",
                 "ios"
             ]
+        },
+        {
+            "name": "stringVariable == 'first' ? 1 : (stringVariable == 'second' ? 2 : (stringVariable == 'third' && intVariable < 42 ? 3 : 4)) => 3",
+            "expression": "@{stringVariable == 'first' ? 1 : (stringVariable == 'second' ? 2 : (stringVariable == 'third' && intVariable < 42 ? 3 : 4))}",
+            "expected": {
+                "type": "integer",
+                "value": 3
+            },
+            "variables": [
+                {
+                    "name": "stringVariable",
+                    "type": "string",
+                    "value": "third"
+                },
+                {
+                    "name": "intVariable",
+                    "type": "integer",
+                    "value": 41
+                }
+            ],
+            "platforms": [
+                "ios"
+            ]
         }
     ]
 }


### PR DESCRIPTION
There are not enough examples of a nested operator, because when using nested operators, you need to implicitly add parentheses. Otherwise, the ternary operator in the expression is interpreted as an infix:

```JSON
"expression": "@{stringVariable == 'first' ? 1 : stringVariable == 'second' ? 2 : stringVariable == 'third' && intVariable < 42 ? 3 : 4}"
```

Causes an error:

```
ExpressionError(error.makeOutputMessage(for: expression), expression: link.rawValue)
(DivKit.ExpressionError) {
  message = "Undefined infix operator ?"
  ...
}
```

Therefore, the proposed pull request contains an additional example of a test case with nested ternary operators.