### PR TITLE
fix(flutter): fix gradients in templates breaks rendering

### DIFF
--- a/client/flutter/divkit/lib/src/core/template/resolver.dart
+++ b/client/flutter/divkit/lib/src/core/template/resolver.dart
@@ -298,6 +298,11 @@ class TemplatesResolver {
         } else if (value is Arr) {
           final list = [];
           for (final e in value) {
+            if (e != null && e is! Obj) {
+              list.add(e);
+              continue;
+            }
+
             final res = await _replace(e ?? value, e, ctx);
             for (final r in res.used) {
               if (result.containsKey(r)) {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: [link](https://yandex.ru/legal/cla/?lang=en)

When gradients are used in template, there is TypeError occurring during template parsing. 
Resolver is not expecting an array of strings. Probably other features using arrays of not objects are affected

Error:

```
_TypeError (type 'String' is not a subtype of type 'Map<String, dynamic>')
```

<details>
<summary>Problematic card example</summary>

```json
{
  "card": {
    "log_id": "gradient_error",
    "states": [
      {
        "state_id": 0,
        "div": {
          "type": "example"
        }
      }
    ]
  },
  "templates": {
    "example": {
      "type": "container",
      "height": {
        "type": "fixed",
        "value": 100
      },
      "background": [
        {
          "type": "gradient",
          "colors": [
            "#999",
            "#fff"
          ],
          "angle": 45
        }
      ],
      "content_alignment_vertical": "center",
      "content_alignment_horizontal": "center",
      "items": [
        {
          "type": "text",
          "text": "Gradient in templates example",
          "width": {
            "type": "wrap_content"
          }
        }
      ]
    }
  }
}
```

</details>

### Notes

This pull request fixes this error. 
Change is simply to pass not object value as is without processing by `TemplatesResolver._replace_`