### PR TITLE
[iOS] Added avg method for array

### DIFF
--- a/client/ios/DivKit/Expressions/Functions/ArrayFunctions.swift
+++ b/client/ios/DivKit/Expressions/Functions/ArrayFunctions.swift
@@ -41,6 +41,7 @@ extension [String: Function] {
     addFunction("getString", _getString)
     addFunction("getUrl", _getUrl)
     addFunction("isEmpty", _isEmpty)
+    addFunction("avg", _avg)
   }
 
   private mutating func addFunctions(
@@ -86,6 +87,21 @@ private let _getUrl = FunctionBinary<[AnyHashable], Int, URL> {
 
 private let _isEmpty = FunctionUnary<[AnyHashable], Bool> {
   $0.isEmpty
+}
+
+private let _avg = FunctionUnary<[AnyHashable], Double> {
+    let array: [AnyHashable] = $0
+
+    guard array is [Double] || array is [Int] else {
+        throw ExpressionError.incorrectType("unsupportedType", array.self)
+    }
+
+    if let array = array as? [Double] {
+        return Double(array.reduce(0,+)) / Double(array.count)
+    } else if let array = array as? [Int] {
+        return Double(array.reduce(0,+)) / Double(array.count)
+    }
+    return .zero
 }
 
 private let _getOptArray = FunctionBinary<[AnyHashable], Int, [AnyHashable]> {

--- a/test_data/expression_test_data/methods_array.json
+++ b/test_data/expression_test_data/methods_array.json
@@ -275,6 +275,48 @@
       ]
     },
     {
+      "expression": "@{array_var.avg()}",
+      "expected": {
+        "type": "number",
+        "value": 9.0
+      },
+      "variables": [
+        {
+          "name": "array_var",
+          "type": "array",
+          "value": [
+            8,
+            9,
+            10
+          ]
+        }
+      ],
+      "platforms": [
+        "ios"
+      ]
+    },
+    {
+      "expression": "@{array_var.avg()}",
+      "expected": {
+        "type": "error",
+        "value": "Failed to evaluate [avg()]. Incorrect value type: expected unsupportedType, got Array."
+      },
+      "variables": [
+        {
+          "name": "array_var",
+          "type": "array",
+          "value": [
+            "one",
+            "two",
+            "three"
+          ]
+        }
+      ],
+      "platforms": [
+        "ios"
+      ]
+    },
+    {
       "expression": "@{array_var.isEmpty()}",
       "expected": {
         "type": "boolean",


### PR DESCRIPTION
Реализация issue - https://github.com/divkit/divkit/issues/64

Работает только если все элементы имеют тип integer или number.
Если встречается элемент другого типа, то выбрасываем ошибку unsupportedType.
(https://github.com/divkit/divkit/blob/main/client/ios/DivKit/Expressions/Functions/ArrayFunctions.swift#L43).
Пример использования:
```JSON
{
    "card": {
        "log_id": "div2_sample_card",
        "states": [
            {
                "state_id": 0,
                "div": {
                    "variables": [
                        {
                            "name": "source",
                            "type": "array",
                            "value": [10, 9, 8]
                        }
                    ],
                    "type": "text",
                    "text": "@{source.avg()}"   
                }
            }
        ]
    }
}
```