### PR TITLE
Добавление возможности выполнять див экшны в дебаг панели на Android

### DIFF
--- a/client/android/div/src/main/java/com/yandex/div/core/view2/errors/ErrorView.kt
+++ b/client/android/div/src/main/java/com/yandex/div/core/view2/errors/ErrorView.kt
@@ -7,6 +7,7 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.graphics.Color
 import android.os.TransactionTooLargeException
+import android.view.ContextThemeWrapper
 import android.view.Gravity
 import android.view.ViewGroup
 import android.view.ViewGroup.MarginLayoutParams
@@ -249,20 +250,33 @@ private class DetailsViewGroup(
         setPadding(24, 12, 24, 12)
         setBackgroundResource(R.drawable.action_box_background)
         setHorizontallyScrolling(true)
+        setHintTextColor(Color.parseColor("#bbbbbb"))
+        hint = "div-action://some_action?arg=value..."
     }
 
+    @SuppressLint("SetTextI18n")
     private fun createActionExecutionBox() = LinearLayout(context).apply {
         orientation = VERTICAL
 
         addView(
-            actionInput, LayoutParams(
-                LayoutParams.MATCH_PARENT,
+            AppCompatTextView(context).apply {
+                text = "Enter array of div-actions, single action or action url:"
+                setTextColor(Color.WHITE)
+                setPadding(0, 0, 0, 12)
+            },
+            LayoutParams(
                 LayoutParams.WRAP_CONTENT,
-                1f
+                LayoutParams.WRAP_CONTENT,
             )
         )
         addView(
-            Button(context).apply {
+            actionInput, LayoutParams(
+                LayoutParams.MATCH_PARENT,
+                LayoutParams.WRAP_CONTENT,
+            )
+        )
+        addView(
+            Button(ContextThemeWrapper(context, android.R.style.Theme_Material)).apply {
                 text = "execute"
                 setOnClickListener { onExecuteAction(actionInput.text.toString()) }
             },

--- a/client/android/div/src/main/java/com/yandex/div/core/view2/errors/ErrorView.kt
+++ b/client/android/div/src/main/java/com/yandex/div/core/view2/errors/ErrorView.kt
@@ -21,7 +21,6 @@ import com.yandex.div.core.Disposable
 import com.yandex.div.core.expression.variables.VariableController
 import com.yandex.div.core.view2.divs.dpToPx
 import com.yandex.div.internal.Assert
-import com.yandex.div.internal.KLog
 import com.yandex.div.internal.widget.FrameContainerLayout
 
 internal class ErrorView(
@@ -76,6 +75,9 @@ internal class ErrorView(
         }
 
         val view = DetailsViewGroup(root.context, errorModel.getErrorHandler(),
+            onExecuteAction = { actionString ->
+                errorModel.executeAction(actionString)
+            },
             onCloseAction = {
                 errorModel.hideDetails()
             },
@@ -167,6 +169,7 @@ internal class ErrorView(
 private class DetailsViewGroup(
     context: Context,
     errorHandler: (Throwable) -> Unit,
+    private val onExecuteAction: (String) -> Unit,
     private val onCloseAction: () -> Unit,
     private val onCopyAction: () -> Unit,
 ) : LinearLayout(context) {
@@ -261,11 +264,7 @@ private class DetailsViewGroup(
         addView(
             Button(context).apply {
                 text = "execute"
-                setOnClickListener {
-                    KLog.i("execution button") {
-                        "execution button clicked, action input is: ${actionInput.text}"
-                    }
-                }
+                setOnClickListener { onExecuteAction(actionInput.text.toString()) }
             },
             LayoutParams(
                 LayoutParams.WRAP_CONTENT,

--- a/client/android/div/src/main/java/com/yandex/div/core/view2/errors/ErrorView.kt
+++ b/client/android/div/src/main/java/com/yandex/div/core/view2/errors/ErrorView.kt
@@ -10,6 +10,8 @@ import android.os.TransactionTooLargeException
 import android.view.Gravity
 import android.view.ViewGroup
 import android.view.ViewGroup.MarginLayoutParams
+import android.widget.Button
+import android.widget.EditText
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.Toast
@@ -19,6 +21,7 @@ import com.yandex.div.core.Disposable
 import com.yandex.div.core.expression.variables.VariableController
 import com.yandex.div.core.view2.divs.dpToPx
 import com.yandex.div.internal.Assert
+import com.yandex.div.internal.KLog
 import com.yandex.div.internal.widget.FrameContainerLayout
 
 internal class ErrorView(
@@ -171,6 +174,7 @@ private class DetailsViewGroup(
     private val variableMonitor = VariableMonitor(errorHandler)
 
     private val errorsOutput = createErrorsOutput()
+    private val actionInput = createActionInput()
     private val monitorView = VariableMonitorView(context, variableMonitor)
 
     init {
@@ -237,6 +241,39 @@ private class DetailsViewGroup(
         gravity = Gravity.LEFT
     }
 
+    private fun createActionInput() = EditText(context).apply {
+        setTextColor(Color.WHITE)
+        setPadding(24, 12, 24, 12)
+        setBackgroundResource(R.drawable.action_box_background)
+        setHorizontallyScrolling(true)
+    }
+
+    private fun createActionExecutionBox() = LinearLayout(context).apply {
+        orientation = VERTICAL
+
+        addView(
+            actionInput, LayoutParams(
+                LayoutParams.MATCH_PARENT,
+                LayoutParams.WRAP_CONTENT,
+                1f
+            )
+        )
+        addView(
+            Button(context).apply {
+                text = "execute"
+                setOnClickListener {
+                    KLog.i("execution button") {
+                        "execution button clicked, action input is: ${actionInput.text}"
+                    }
+                }
+            },
+            LayoutParams(
+                LayoutParams.WRAP_CONTENT,
+                LayoutParams.WRAP_CONTENT,
+            )
+        )
+    }
+
     private fun configureView() {
         val padding = 8.dpToPx(resources.displayMetrics)
         setPadding(padding, padding, padding, padding)
@@ -247,6 +284,12 @@ private class DetailsViewGroup(
         addView(
             createTopPanel(), LayoutParams(
                 LayoutParams.WRAP_CONTENT,
+                LayoutParams.WRAP_CONTENT,
+            )
+        )
+        addView(
+            createActionExecutionBox(), LayoutParams(
+                LayoutParams.MATCH_PARENT,
                 LayoutParams.WRAP_CONTENT,
             )
         )

--- a/client/android/div/src/main/java/com/yandex/div/core/view2/errors/ErrorVisualMonitor.kt
+++ b/client/android/div/src/main/java/com/yandex/div/core/view2/errors/ErrorVisualMonitor.kt
@@ -1,5 +1,6 @@
 package com.yandex.div.core.view2.errors
 
+import android.net.Uri
 import android.view.ViewGroup
 import com.yandex.div.core.Disposable
 import com.yandex.div.core.actions.logError
@@ -11,8 +12,12 @@ import com.yandex.div.core.expression.variables.VariableController
 import com.yandex.div.core.view2.Binding
 import com.yandex.div.core.view2.Div2View
 import com.yandex.div.core.view2.ViewBindingProvider
+import com.yandex.div.data.DivParsingEnvironment
+import com.yandex.div.json.ParsingErrorLogger
 import com.yandex.div.json.ParsingException
+import com.yandex.div2.DivAction
 import org.json.JSONArray
+import org.json.JSONException
 import org.json.JSONObject
 import javax.inject.Inject
 
@@ -178,6 +183,21 @@ internal class ErrorModel(
             result[path] = runtime.variableController
         }
         return result
+    }
+
+    fun executeAction(action: String) {
+        try {
+            val actionJson = JSONObject(action)
+            val divAction = DivAction(
+                DivParsingEnvironment(ParsingErrorLogger.LOG),
+                actionJson
+            )
+            div2View.handleAction(divAction)
+        }
+        catch (e: JSONException) {
+            val uri = Uri.parse(action)
+            div2View.handleUri(uri)
+        }
     }
 
     fun getErrorHandler(): (Throwable) -> Unit {

--- a/client/android/div/src/main/java/com/yandex/div/core/view2/errors/ErrorVisualMonitor.kt
+++ b/client/android/div/src/main/java/com/yandex/div/core/view2/errors/ErrorVisualMonitor.kt
@@ -13,16 +13,12 @@ import com.yandex.div.core.view2.Binding
 import com.yandex.div.core.view2.Div2View
 import com.yandex.div.core.view2.ViewBindingProvider
 import com.yandex.div.data.DivParsingEnvironment
-import com.yandex.div.evaluable.types.Url
-import com.yandex.div.internal.KLog
 import com.yandex.div.internal.util.map
 import com.yandex.div.json.ParsingErrorLogger
 import com.yandex.div.json.ParsingException
 import com.yandex.div2.DivAction
 import org.json.JSONArray
-import org.json.JSONException
 import org.json.JSONObject
-import java.net.URL
 import javax.inject.Inject
 
 private const val SHOW_LIMIT = 25

--- a/client/android/div/src/main/res/drawable/action_box_background.xml
+++ b/client/android/div/src/main/res/drawable/action_box_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="4dp" />
+    <stroke android:width="1dp" android:color="#eeeeee"/>
+    <solid android:color="#32000000" />
+</shape>


### PR DESCRIPTION
В дебаг панель демо аппа для Android добавленно текстовое поле для ввода див-экшнов и кнопка для их исполнения. 
Можно ввести список список экшнов или один экшн в формате json (https://divkit.tech/docs/ru/concepts/divs/2/div-action), так же можно ввести экшн в виде url. 
Все экшны будут и выполнены на корневом див-вью, так же, как они выполняются в интерактивных тестах. 

Вот так выглядит
![image](https://github.com/user-attachments/assets/38166416-17d2-4868-87c7-6cc4d512fe96)


I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru.