### PR TITLE
fix(iOS): prevent unnecessary `TabContentsView` reloads affecting `TextInput` focus

### DIFF
--- a/client/ios/LayoutKit/LayoutKit/UI/Views/TabbedPages/TabContentsView.swift
+++ b/client/ios/LayoutKit/LayoutKit/UI/Views/TabbedPages/TabContentsView.swift
@@ -194,7 +194,11 @@ final class TabContentsView: BlockView {
           )
         }
       layout = nil
-      collectionView.reloadData()
+      if oldModel?.pages.count == model.pages.count {
+        configureVisibleCells(cellModels)
+      } else {
+        collectionView.reloadData()
+      }
     }
 
     collectionView.isScrollEnabled = model.scrollingEnabled
@@ -202,6 +206,19 @@ final class TabContentsView: BlockView {
     if oldModel != model || layout == nil || state.selectedPageIndex != selectedPageIndex {
       updateSelectedPageIndexIfNeeded(state.selectedPageIndex)
       setNeedsLayout()
+    }
+  }
+
+  private func configureVisibleCells(_ blocks: [Block]) {
+    let cells = collectionView.visibleCells.map { $0 as! GenericCollectionViewCell }
+    for (cell, indexPath) in zip(cells, collectionView.indexPathsForVisibleItems) {
+      cell.configure(
+        model: blocks[indexPath.row],
+        observer: observer,
+        overscrollDelegate: overscrollDelegate,
+        renderingDelegate: renderingDelegate,
+        accessibilityElement: blocks[indexPath.row].accessibilityElement
+      )
     }
   }
 


### PR DESCRIPTION
## Problem
Text input fields in tabbed pages were losing focus due to unnecessary collection view reloads in `TabContentsView`. See more here #117. 

## Solution
Added reload pattern similar to GalleryView/PagerBlock:
- Only do full `collectionView.reloadData()` when page count changes
- Use `configureVisibleCells()` when page count is same to preserve text input focus

I hereby agree to the terms of the CLA available at https://yandex.ru/legal/cla/