### PR TITLE
fix ANR caused by check-then-acquire race in BindingDispatcher.withLock & add tests

### DIFF
--- a/client/android/div/src/main/java/com/yandex/div/core/util/binding/BindingCriticalSection.kt
+++ b/client/android/div/src/main/java/com/yandex/div/core/util/binding/BindingCriticalSection.kt
@@ -149,6 +149,44 @@ internal class BindingCriticalSection @Inject constructor() {
     }
 
     /**
+     * Tries to enter the critical section without blocking.
+     *
+     * Returns immediately with a [Disposable] handle if the section is free (or already
+     * held by the current thread), or `null` if it is held by — or reserved for —
+     * a different thread.
+     *
+     * Intended for the main thread to avoid an indefinite [LockSupport.park] when a
+     * background binding is in progress (see [BindingDispatcher.withLock]).
+     *
+     * @return A [Disposable] handle on success, or `null` if the section cannot be
+     *         acquired immediately by the current thread.
+     */
+    @AnyThread
+    fun tryEnter(): Disposable? {
+        synchronized(lock) {
+            val thread = Thread.currentThread()
+            when (holder) {
+                null -> {
+                    if (reserver != null && reserver != thread) {
+                        return null
+                    }
+                    holder = thread
+                    reserver = null
+                    entranceCounter = 1
+                    return EntranceHandle(this)
+                }
+
+                thread -> {
+                    entranceCounter++
+                    return EntranceHandle(this)
+                }
+
+                else -> return null
+            }
+        }
+    }
+
+    /**
      * Enters the critical section.
      *
      * If the section is not held, the current thread becomes the holder.

--- a/client/android/div/src/main/java/com/yandex/div/core/util/binding/BindingDispatcher.kt
+++ b/client/android/div/src/main/java/com/yandex/div/core/util/binding/BindingDispatcher.kt
@@ -142,11 +142,26 @@ internal class BindingDispatcher @Inject constructor(
     /**
      * Use from methods which could be externally called from main thread while background binding is in progress.
      * In such case, rejects the execution returning [fallback].
+     *
+     * Acquisition is done with [BindingCriticalSection.tryEnter] on the main thread —
+     * a single atomic operation inside the section's lock. The previous implementation
+     * read [isBackgroundBindingInProgress] and then called the blocking
+     * [BindingCriticalSection.enter]; between those two steps the binding thread could
+     * call [BindingCriticalSection.reserveFor], leaving the main thread parked indefinitely.
+     * `tryEnter` collapses check and acquire into one synchronized block, so no such
+     * window can open.
+     *
+     * Off the main thread we still use the blocking [withLockInternal] path, because
+     * background binding tasks are expected to serialize against each other.
      */
     inline fun <T> withLock(fallback: T, block: () -> T): T {
-        if (isBackgroundBindingInProgress && UiThreadHandler.get().isMainThread()) {
-            reportLockFail()
-            return fallback
+        if (UiThreadHandler.get().isMainThread()) {
+            val handle = criticalSection.tryEnter()
+            if (handle == null) {
+                reportLockFail()
+                return fallback
+            }
+            return handle.use { block() }
         }
 
         return withLockInternal(block)

--- a/client/android/div/src/test/java/com/yandex/div/core/util/binding/BindingCriticalSectionTest.kt
+++ b/client/android/div/src/test/java/com/yandex/div/core/util/binding/BindingCriticalSectionTest.kt
@@ -1,0 +1,270 @@
+package com.yandex.div.core.util.binding
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Unit tests for [BindingCriticalSection].
+ *
+ * Focus: the cross-thread transfer + reentrant path introduced when
+ * [BindingDispatcher.runOnBindingThread] calls [transferToCurrentThread] before invoking
+ * onComplete on the main thread. Without the transfer, a reentrant `setData` triggered
+ * inside onComplete would observe `holder == bindingThread` and either be silently dropped
+ * by `withLock` or — historically, before the tryEnter-based fix — park the main thread
+ * indefinitely.
+ */
+internal class BindingCriticalSectionTest {
+
+    private val section = BindingCriticalSection()
+
+    // region tryEnter — each branch of the new method
+
+    @Test
+    fun `tryEnter on free section acquires lock`() {
+        val handle = section.tryEnter()
+
+        assertNotNull("Expected free section to be acquirable", handle)
+        assertTrue(section.isHeld)
+        assertTrue(section.isHeldBy(Thread.currentThread()))
+
+        section.exit(handle!!)
+        assertFalse(section.isHeld)
+    }
+
+    @Test
+    fun `tryEnter is reentrant for current holder`() {
+        val handle1 = section.tryEnter()!!
+        val handle2 = section.tryEnter()
+
+        assertNotNull("Reentrant tryEnter must succeed for current holder", handle2)
+
+        // Releasing the inner handle keeps the lock held by the outer one.
+        section.exit(handle2!!)
+        assertTrue(section.isHeld)
+
+        section.exit(handle1)
+        assertFalse(section.isHeld)
+    }
+
+    @Test
+    fun `tryEnter returns null when held by another thread`() {
+        val acquired = CountDownLatch(1)
+        val release = CountDownLatch(1)
+
+        val owner = Thread {
+            val handle = section.tryEnter()!!
+            acquired.countDown()
+            release.await()
+            section.exit(handle)
+        }
+        owner.start()
+        acquired.await()
+
+        // Main thread must NOT block here — that was the original ANR.
+        val handle = section.tryEnter()
+        assertNull("tryEnter must return null when another thread holds the lock", handle)
+
+        release.countDown()
+        owner.join()
+    }
+
+    @Test
+    fun `tryEnter returns null when reserved for another thread`() {
+        val other = Thread { /* never runs body */ }
+        section.reserveFor(other)
+
+        val handle = section.tryEnter()
+        assertNull(
+            "tryEnter must not steal a lock reserved for a different thread — " +
+                "doing so would let two threads execute the binding block concurrently",
+            handle
+        )
+
+        section.cancelReservation()
+    }
+
+    @Test
+    fun `tryEnter succeeds when reserved for current thread`() {
+        section.reserveFor(Thread.currentThread())
+
+        val handle = section.tryEnter()
+        assertNotNull("Reservation for current thread must allow acquisition", handle)
+        // Reservation must be cleared on successful acquisition (matches enter() semantics).
+        assertFalse(section.isReserved)
+
+        section.exit(handle!!)
+    }
+
+    // endregion
+
+    // region transfer + reentrant path — the scenario added by BindingDispatcher.runOnBindingThread fix
+
+    /**
+     * Simulates the patched `runOnBindingThread(onComplete)` flow:
+     *   1. binding thread reserveFor + enter
+     *   2. binding thread executes block, posts to main
+     *   3. main thread transferToCurrentThread, runs onComplete (which reentrantly enters the section), exits
+     *
+     * Verifies: holder ends as null, entranceCounter unwinds correctly, no thread is left parked.
+     */
+    @Test
+    fun `transfer to main then reentrant enter then exit unwinds cleanly`() {
+        val mainExecuted = AtomicBoolean(false)
+        val reentrantExecuted = AtomicBoolean(false)
+
+        // Step 1+2: binding thread enters the section.
+        val bindingThread = Thread.currentThread() // simulate "binding thread" as current
+        section.reserveFor(bindingThread)
+        val handle = section.enter()
+        assertTrue(section.isHeldBy(bindingThread))
+
+        // Step 3: simulate post to main thread by running on a new thread that "becomes" the
+        // main thread after transferToCurrentThread.
+        val mainLatch = CountDownLatch(1)
+        val mainThread = Thread {
+            section.transferToCurrentThread()
+            assertTrue(
+                "After transfer, holder must be the (simulated) main thread",
+                section.isHeldBy(Thread.currentThread())
+            )
+
+            // Reentrant tryEnter from inside onComplete — this is the path withLock takes.
+            val innerHandle = section.tryEnter()
+            assertNotNull(
+                "Reentrant tryEnter from main thread must succeed after transfer",
+                innerHandle
+            )
+            reentrantExecuted.set(true)
+            section.exit(innerHandle!!)
+
+            // Outer counter should still be 1 — outer handle still owns the lock.
+            assertTrue(section.isHeld)
+
+            mainExecuted.set(true)
+            section.exit(handle)
+
+            mainLatch.countDown()
+        }
+        mainThread.start()
+        assertTrue("Main-thread simulation timed out", mainLatch.await(2, TimeUnit.SECONDS))
+        mainThread.join()
+
+        assertTrue(mainExecuted.get())
+        assertTrue(reentrantExecuted.get())
+        assertFalse("Lock must be fully released after onComplete unwinds", section.isHeld)
+        assertFalse(section.isReserved)
+    }
+
+    /**
+     * Without the [transferToCurrentThread] call — i.e. the OLD buggy path — a reentrant
+     * tryEnter from a thread that is NOT the holder must return null. This pins the contract
+     * that motivated the fix: if we forget to transfer, we MUST NOT silently acquire the
+     * lock under a different identity.
+     */
+    @Test
+    fun `reentrant tryEnter without transfer returns null on different thread`() {
+        val handle = section.enter() // current thread holds it
+
+        val outcome = AtomicReference<Any?>("not-set")
+        val done = CountDownLatch(1)
+        Thread {
+            // Different thread — no transferToCurrentThread.
+            outcome.set(section.tryEnter())
+            done.countDown()
+        }.start()
+        assertTrue(done.await(2, TimeUnit.SECONDS))
+
+        assertNull(
+            "tryEnter from a non-holder thread must return null — never steal the lock",
+            outcome.get()
+        )
+
+        section.exit(handle)
+    }
+
+    // endregion
+
+    // region concurrency / liveness — ensure tryEnter never deadlocks the main thread
+
+    @Test
+    fun `tryEnter contention does not deadlock the calling thread`() {
+        // Spawn N threads that all try to acquire+release in a tight loop. None should park.
+        val workers = 8
+        val iterations = 500
+        val start = CountDownLatch(1)
+        val finished = CountDownLatch(workers)
+        val acquireCount = AtomicInteger(0)
+        val rejectCount = AtomicInteger(0)
+
+        repeat(workers) {
+            Thread {
+                start.await()
+                repeat(iterations) {
+                    val h = section.tryEnter()
+                    if (h != null) {
+                        acquireCount.incrementAndGet()
+                        section.exit(h)
+                    } else {
+                        rejectCount.incrementAndGet()
+                    }
+                }
+                finished.countDown()
+            }.start()
+        }
+
+        start.countDown()
+        // 5s is generous; tryEnter should never block, so this loop is CPU-bound.
+        val finishedInTime = finished.await(5, TimeUnit.SECONDS)
+        if (!finishedInTime) {
+            fail("tryEnter contention deadlocked — some workers never finished")
+        }
+
+        assertEquals(workers * iterations, acquireCount.get() + rejectCount.get())
+        assertFalse("Lock must end up released", section.isHeld)
+    }
+
+    @Test
+    fun `transfer pattern survives interleaving with main thread tryEnter`() {
+        // Models the real ANR scenario:
+        //  - background thread holds the lock
+        //  - main thread repeatedly calls tryEnter (would have parked under the old design)
+        //  - background completes, posts to main, transfers, runs reentrant tryEnter
+        val backgroundHolds = CountDownLatch(1)
+        val mainProbed = CountDownLatch(1)
+        val release = CountDownLatch(1)
+
+        val bg = Thread {
+            val h = section.enter()
+            backgroundHolds.countDown()
+            mainProbed.await()
+            release.await()
+            // Simulate post-to-main: transfer + exit on a different thread.
+            // For this test, we just exit on the same thread — the contract checked here is
+            // that main-thread tryEnter is non-blocking while bg holds.
+            section.exit(h)
+        }
+        bg.start()
+        backgroundHolds.await()
+
+        val mainOutcome = section.tryEnter()
+        assertNull(
+            "Main thread tryEnter must return null instantly while background holds the lock",
+            mainOutcome
+        )
+        mainProbed.countDown()
+        release.countDown()
+        bg.join()
+
+        assertFalse(section.isHeld)
+    }
+}

--- a/client/android/div/src/test/java/com/yandex/div/core/util/binding/BindingDispatcherTest.kt
+++ b/client/android/div/src/test/java/com/yandex/div/core/util/binding/BindingDispatcherTest.kt
@@ -1,0 +1,223 @@
+package com.yandex.div.core.util.binding
+
+import com.yandex.div.core.util.EnableAssertsRule
+import com.yandex.div.core.view2.Div2View
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowLooper
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Integration tests for [BindingDispatcher].
+ *
+ * Pins the contract for the two SDK changes:
+ *   1. `withLock` uses [BindingCriticalSection.tryEnter] on the main thread, so the main thread
+ *      never parks indefinitely during contention.
+ *   2. `runOnBindingThread(onComplete, ...)` calls [BindingCriticalSection.transferToCurrentThread]
+ *      before invoking onComplete, so a `setData` (i.e. `withLock`) call triggered inside the
+ *      callback is NOT silently dropped. Without the transfer, holder would still be the
+ *      binding thread and `withLock` would return the fallback.
+ *
+ * The tests run under [RobolectricTestRunner] so [com.yandex.div.internal.util.UiThreadHandler]
+ * uses a real Robolectric main looper (different from the binding thread). This is what makes
+ * the transfer behavior observable — under [TestUiThreadHandler], every thread is treated as
+ * the main thread, which would mask the bug.
+ */
+@RunWith(RobolectricTestRunner::class)
+internal class BindingDispatcherTest {
+
+    // reportLockFail() invokes KAssert.fail. With asserts enabled it would throw
+    // AssertionError and break the ANR-regression test, which expects withLock to
+    // return the fallback gracefully when contended.
+    @get:Rule
+    val disableAsserts = EnableAssertsRule(enable = false)
+
+    private val divView = mock<Div2View>()
+    private val criticalSection = BindingCriticalSection()
+    private val executor = BindingThreadExecutor.create("test-binding-thread")
+    private val dispatcher = BindingDispatcher(divView, criticalSection, executor)
+
+    @After
+    fun tearDown() {
+        // Drain any pending main-thread work so it does not leak into the next test.
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+    }
+
+    /**
+     * `withLock` on a free section must execute the block and return its result.
+     */
+    @Test
+    fun `withLock executes block on free section`() {
+        val result = dispatcher.withLock(fallback = -1) { 42 }
+
+        assertEquals(42, result)
+        assertFalse(criticalSection.isHeld)
+    }
+
+    /**
+     * `withLock` must return the fallback (and NOT park) when another thread holds the section.
+     * This is the regression test for the original ANR.
+     */
+    @Test(timeout = 5_000)
+    fun `withLock returns fallback when another thread holds the lock instead of parking`() {
+        val acquired = CountDownLatch(1)
+        val release = CountDownLatch(1)
+
+        val owner = Thread {
+            val handle = criticalSection.enter()
+            acquired.countDown()
+            release.await()
+            criticalSection.exit(handle)
+        }
+        owner.start()
+        acquired.await()
+
+        // Would have parked indefinitely under the old check-then-enter implementation.
+        val result = dispatcher.withLock(fallback = "fallback") { "executed" }
+        assertEquals("fallback", result)
+
+        release.countDown()
+        owner.join()
+    }
+
+    /**
+     * Core regression test for the fix in `runOnBindingThread`: when onComplete runs on the
+     * main thread, [BindingCriticalSection.transferToCurrentThread] must have moved holder
+     * from the binding thread to the main thread. Otherwise a reentrant `withLock` from inside
+     * onComplete sees `holder == bindingThread`, [BindingCriticalSection.tryEnter] returns null,
+     * and the reentrant block is silently replaced with the fallback.
+     *
+     * The block runs on the binding thread; onComplete is posted to the Robolectric main
+     * looper, so we drive it forward with [ShadowLooper.runUiThreadTasksIncludingDelayedTasks].
+     */
+    @Test(timeout = 5_000)
+    fun `withLock inside onComplete executes its block — proves transferToCurrentThread happened`() {
+        val blockThread = AtomicReference<Thread>()
+        val onCompleteThread = AtomicReference<Thread>()
+        val reentrantOutcome = AtomicReference<String>("not-set")
+        val reentrantBlockRan = AtomicInteger(0)
+        val onCompleteRan = CountDownLatch(1)
+
+        dispatcher.runOnBindingThread<Unit>(
+            onComplete = { _ ->
+                onCompleteThread.set(Thread.currentThread())
+
+                // This is the path that was silently dropped before the fix.
+                val result = dispatcher.withLock(fallback = "DROPPED") {
+                    reentrantBlockRan.incrementAndGet()
+                    "executed"
+                }
+                reentrantOutcome.set(result)
+
+                onCompleteRan.countDown()
+            }
+        ) {
+            blockThread.set(Thread.currentThread())
+        }
+
+        // Drive the main looper so onComplete actually fires.
+        // Loop a few times because tasks may post follow-ups.
+        repeat(10) {
+            ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+            if (onCompleteRan.count == 0L) return@repeat
+            Thread.sleep(20)
+        }
+        assertTrue("onComplete never fired", onCompleteRan.await(2, TimeUnit.SECONDS))
+
+        // Sanity: block ran on a real binding thread, onComplete on the main thread.
+        assertNotNull(blockThread.get())
+        assertNotNull(onCompleteThread.get())
+        assertTrue(
+            "binding thread and main thread should be different",
+            blockThread.get() != onCompleteThread.get()
+        )
+
+        assertEquals(
+            "Reentrant withLock inside onComplete MUST execute its block. " +
+                "Got fallback instead — this means transferToCurrentThread() was missing.",
+            "executed",
+            reentrantOutcome.get()
+        )
+        assertEquals(1, reentrantBlockRan.get())
+
+        // Drain any trailing posts and verify clean unwind.
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+        assertFalse("Section must be released after onComplete unwinds", criticalSection.isHeld)
+        assertFalse(criticalSection.isReserved)
+    }
+
+    /**
+     * Multiple sequential `withLock` calls inside onComplete must all execute their block —
+     * the transferred ownership stays with the main thread for the entire callback.
+     */
+    @Test(timeout = 5_000)
+    fun `multiple sequential withLock calls inside onComplete all succeed`() {
+        val successes = AtomicInteger(0)
+        val done = CountDownLatch(1)
+
+        dispatcher.runOnBindingThread<Unit>(
+            onComplete = { _ ->
+                repeat(3) {
+                    dispatcher.withLock(fallback = false) {
+                        successes.incrementAndGet()
+                        true
+                    }
+                }
+                done.countDown()
+            }
+        ) {
+            // no-op binding work
+        }
+
+        repeat(10) {
+            ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+            if (done.count == 0L) return@repeat
+            Thread.sleep(20)
+        }
+        assertTrue(done.await(2, TimeUnit.SECONDS))
+        assertEquals(3, successes.get())
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+        assertFalse(criticalSection.isHeld)
+    }
+
+    /**
+     * `runOnBindingThread` without onComplete must release the lock from the binding thread
+     * (the legacy path). Verifies the fix didn't break the no-callback branch.
+     */
+    @Test(timeout = 5_000)
+    fun `runOnBindingThread without onComplete releases lock from binding thread`() {
+        val ran = CountDownLatch(1)
+
+        dispatcher.runOnBindingThread<Unit>(onComplete = null) {
+            ran.countDown()
+        }
+
+        assertTrue(ran.await(3, TimeUnit.SECONDS))
+
+        // The exit happens in the binding thread's finally block right after our block returns;
+        // give it a brief moment to land before asserting.
+        val deadline = System.currentTimeMillis() + 1_000
+        while (criticalSection.isHeld && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10)
+        }
+        assertFalse("Section must be released even without onComplete", criticalSection.isHeld)
+        assertFalse(criticalSection.isReserved)
+
+        // And the section must be reusable afterwards.
+        val handle = criticalSection.tryEnter()
+        assertNotNull(handle)
+        criticalSection.exit(handle!!)
+    }
+}


### PR DESCRIPTION
I encountered an ANR during usage and submitted an issue for it. This is my fix for the corresponding problem.


I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
