### PR TITLE
fix(glide): use a dedicated transcode class for SVG requests

### DIFF
--- a/client/android/glide/src/main/java/com/yandex/div/glide/GlideDivImageLoader.kt
+++ b/client/android/glide/src/main/java/com/yandex/div/glide/GlideDivImageLoader.kt
@@ -6,6 +6,7 @@ import android.graphics.drawable.PictureDrawable
 import android.net.Uri
 import android.widget.ImageView
 import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestBuilder
 import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.Option
 import com.bumptech.glide.load.Options
@@ -59,8 +60,18 @@ class GlideDivImageLoader @JvmOverloads constructor(
 
         // load result will be handled by RequestListener to get dataSource
         val requestManager = Glide.with(context)
-        requestManager.load(imageUri)
-            .set(Option.memory(KEY_SVG), SvgDecoder.isSvg(imageUrl))
+        // SVG must use a dedicated transcode class: Registry memoizes decoder lookups by
+        // (model, resourceClass, transcodeClass) and append() does not invalidate that memo,
+        // so sharing the asDrawable() key with the host app makes svgDecoder unreachable
+        // as soon as the host issues any load() before this loader is constructed.
+        val request = if (SvgDecoder.isSvg(imageUrl)) {
+            @Suppress("UNCHECKED_CAST")
+            requestManager.`as`(PictureDrawable::class.java)
+                .set(Option.memory(KEY_SVG), true) as RequestBuilder<Drawable>
+        } else {
+            requestManager.asDrawable()
+        }
+        request.load(imageUri)
             .limitImageBitmapSizeIfNeed(canLimitSize)
             .listener(ImageRequestListener(imageUrl, callback))
             .into(target)


### PR DESCRIPTION
Fixes #145.

SVG requests went through `asDrawable()`, so they shared Glide's `modelToResourceClassCache` memo key with the host app's ordinary image loads. Since `Registry.append()` does not invalidate that memo, any host load issued before the first `GlideDivImageLoader` was constructed permanently hid `svgDecoder` from every DivKit SVG request. Routing SVG through `as(PictureDrawable::class.java)` gives it a memo key that only this code path can produce, so the decoder is always registered first.

Verified A/B with an instrumented test on two physical devices: fails before the patch, passes after.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en